### PR TITLE
feat: Optimize MCP schema descriptions to reduce token usage

### DIFF
--- a/src/mcps/author-server/schemas/author-tools-schema.js
+++ b/src/mcps/author-server/schemas/author-tools-schema.js
@@ -8,7 +8,7 @@
 export const authorToolsSchema = [
     {
         name: 'list_authors',
-        description: 'List all authors in the database',
+        description: 'List all authors',
         inputSchema: {
             type: 'object',
             properties: {},
@@ -17,39 +17,39 @@ export const authorToolsSchema = [
     },
     {
         name: 'get_author',
-        description: 'Get detailed information about a specific author',
+        description: 'Get author details',
         inputSchema: {
             type: 'object',
             properties: {
-                author_id: { type: 'integer', description: 'The ID of the author' }
+                author_id: { type: 'integer', description: 'Author ID' }
             },
             required: ['author_id']
         }
     },
     {
         name: 'create_author',
-        description: 'Create a new author',
+        description: 'Create author',
         inputSchema: {
             type: 'object',
             properties: {
-                name: { type: 'string', description: 'Full name of the author' },
-                email: { type: 'string', description: 'Author\'s email address' },
-                bio: { type: 'string', description: 'Author biography' },
-                birth_year: { type: 'integer', description: 'Year of birth' }
+                name: { type: 'string', description: 'Author name' },
+                email: { type: 'string', description: 'Email' },
+                bio: { type: 'string', description: 'Bio' },
+                birth_year: { type: 'integer', description: 'Birth year' }
             },
             required: ['name']
         }
     },
     {
         name: 'update_author',
-        description: 'Update an existing author',
+        description: 'Update author',
         inputSchema: {
             type: 'object',
             properties: {
-                author_id: { type: 'integer', description: 'The ID of the author to update' },
-                name: { type: 'string', description: 'Full name of the author' },
-                bio: { type: 'string', description: 'Author biography' },
-                birth_year: { type: 'integer', description: 'Year of birth' }
+                author_id: { type: 'integer', description: 'Author ID' },
+                name: { type: 'string', description: 'Author name' },
+                bio: { type: 'string', description: 'Bio' },
+                birth_year: { type: 'integer', description: 'Birth year' }
             },
             required: ['author_id']
         }

--- a/src/mcps/book-server/schemas/book-planning-schemas.js
+++ b/src/mcps/book-server/schemas/book-planning-schemas.js
@@ -10,61 +10,61 @@ export const bookPlanningSchemas = {
     // Book structure tools
     create_book: {
         name: 'create_book',
-        description: 'Create a new book in a series',
+        description: 'Create book',
         inputSchema: {
             type: 'object',
             properties: {
                 title: {
                     type: 'string',
-                    description: 'Book title'
+                    description: 'Title'
                 },
                 series_id: {
                     type: 'integer',
-                    description: 'ID of the series this book belongs to'
+                    description: 'Series ID'
                 },
                 book_number: {
                     type: 'integer',
-                    description: 'Position in the series'
+                    description: 'Series position'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
                     default: 'planned',
-                    description: 'Book status'
+                    description: 'Status'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count for the book'
+                    description: 'Target word count'
                 },
                 actual_word_count: {
                     type: 'integer',
                     default: 0,
-                    description: 'Current word count of the book'
+                    description: 'Current word count'
                 },
                 publication_year: {
                     type: 'integer',
-                    description: 'Year of publication'
+                    description: 'Pub year'
                 },
                 description: {
                     type: 'string',
-                    description: 'Book description/summary'
+                    description: 'Description'
                 },
                 isbn: {
                     type: 'string',
-                    description: 'ISBN number'
+                    description: 'ISBN'
                 },
                 page_count: {
                     type: 'integer',
-                    description: 'Number of pages'
+                    description: 'Pages'
                 },
                 cover_image_url: {
                     type: 'string',
-                    description: 'URL to book cover image'
+                    description: 'Cover URL'
                 },
                 genre_names: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre names for this specific book'
+                    description: 'Genre names'
                 }
             },
             required: ['title', 'series_id', 'book_number']
@@ -73,59 +73,59 @@ export const bookPlanningSchemas = {
 
     update_book: {
         name: 'update_book',
-        description: 'Update an existing book',
+        description: 'Update book',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'The ID of the book to update'
+                    description: 'Book ID'
                 },
                 title: {
                     type: 'string',
-                    description: 'Book title'
+                    description: 'Title'
                 },
                 book_number: {
                     type: 'integer',
-                    description: 'Position in the series'
+                    description: 'Series position'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Book status'
+                    description: 'Status'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count for the book'
+                    description: 'Target word count'
                 },
                 actual_word_count: {
                     type: 'integer',
-                    description: 'Current word count of the book'
+                    description: 'Current word count'
                 },
                 publication_year: {
                     type: 'integer',
-                    description: 'Year of publication'
+                    description: 'Pub year'
                 },
                 isbn: {
                     type: 'string',
-                    description: 'ISBN number'
+                    description: 'ISBN'
                 },
                 page_count: {
                     type: 'integer',
-                    description: 'Number of pages'
+                    description: 'Pages'
                 },
                 description: {
                     type: 'string',
-                    description: 'Book description/summary'
+                    description: 'Description'
                 },
                 cover_image_url: {
                     type: 'string',
-                    description: 'URL to book cover image'
+                    description: 'Cover URL'
                 },
                 genre_names: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre names for this specific book'
+                    description: 'Genre names'
                 }
             },
             required: ['book_id']
@@ -134,18 +134,18 @@ export const bookPlanningSchemas = {
 
     get_book: {
         name: 'get_book',
-        description: 'Get detailed information about a specific book',
+        description: 'Get book details',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'The ID of the book'
+                    description: 'Book ID'
                 },
                 include_chapters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include chapter summary information'
+                    description: 'Include chapters'
                 }
             },
             required: ['book_id']
@@ -154,23 +154,23 @@ export const bookPlanningSchemas = {
 
     list_books: {
         name: 'list_books',
-        description: 'List all books, optionally filtered by series',
+        description: 'List books',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Filter by series ID (optional)'
+                    description: 'Series ID filter'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Filter by book status (optional)'
+                    description: 'Status filter'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include chapter and word count statistics'
+                    description: 'Include stats'
                 }
             },
             required: []

--- a/src/mcps/book-server/schemas/book-tools-schema.js
+++ b/src/mcps/book-server/schemas/book-tools-schema.js
@@ -8,23 +8,23 @@
 export const bookToolsSchema = [
     {
         name: 'list_books',
-        description: 'List all books, optionally filtered by series',
+        description: 'List books',
         inputSchema: {
             type: 'object',
             properties: {
-                series_id: { 
-                    type: 'integer', 
-                    description: 'Filter by series ID (optional)' 
+                series_id: {
+                    type: 'integer',
+                    description: 'Series ID filter'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Filter by book status (optional)'
+                    description: 'Status filter'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include chapter and word count statistics'
+                    description: 'Include stats'
                 }
             },
             required: []
@@ -32,18 +32,18 @@ export const bookToolsSchema = [
     },
     {
         name: 'get_book',
-        description: 'Get detailed information about a specific book',
+        description: 'Get book details',
         inputSchema: {
             type: 'object',
             properties: {
-                book_id: { 
-                    type: 'integer', 
-                    description: 'The ID of the book' 
+                book_id: {
+                    type: 'integer',
+                    description: 'Book ID'
                 },
                 include_chapters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include chapter summary information'
+                    description: 'Include chapters'
                 }
             },
             required: ['book_id']
@@ -51,61 +51,61 @@ export const bookToolsSchema = [
     },
     {
         name: 'create_book',
-        description: 'Create a new book in a series',
+        description: 'Create book',
         inputSchema: {
             type: 'object',
             properties: {
-                title: { 
-                    type: 'string', 
-                    description: 'Book title' 
+                title: {
+                    type: 'string',
+                    description: 'Title'
                 },
-                series_id: { 
-                    type: 'integer', 
-                    description: 'ID of the series this book belongs to' 
+                series_id: {
+                    type: 'integer',
+                    description: 'Series ID'
                 },
-                book_number: { 
-                    type: 'integer', 
-                    description: 'Position in the series' 
+                book_number: {
+                    type: 'integer',
+                    description: 'Series position'
                 },
-                status: { 
-                    type: 'string', 
+                status: {
+                    type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
                     default: 'planned',
-                    description: 'Book status' 
+                    description: 'Status'
                 },
-                target_word_count: { 
-                    type: 'integer', 
-                    description: 'Target word count for the book' 
+                target_word_count: {
+                    type: 'integer',
+                    description: 'Target word count'
                 },
-                actual_word_count: { 
-                    type: 'integer', 
+                actual_word_count: {
+                    type: 'integer',
                     default: 0,
-                    description: 'Current word count of the book' 
+                    description: 'Current word count'
                 },
-                publication_year: { 
-                    type: 'integer', 
-                    description: 'Year of publication' 
+                publication_year: {
+                    type: 'integer',
+                    description: 'Pub year'
                 },
-                description: { 
-                    type: 'string', 
-                    description: 'Book description/summary' 
+                description: {
+                    type: 'string',
+                    description: 'Description'
                 },
-                isbn: { 
-                    type: 'string', 
-                    description: 'ISBN number' 
+                isbn: {
+                    type: 'string',
+                    description: 'ISBN'
                 },
-                page_count: { 
-                    type: 'integer', 
-                    description: 'Number of pages' 
+                page_count: {
+                    type: 'integer',
+                    description: 'Pages'
                 },
                 cover_image_url: {
                     type: 'string',
-                    description: 'URL to book cover image'
+                    description: 'Cover URL'
                 },
                 genre_names: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre names for this specific book'
+                    description: 'Genre names'
                 }
             },
             required: ['title', 'series_id', 'book_number']
@@ -113,59 +113,59 @@ export const bookToolsSchema = [
     },
     {
         name: 'update_book',
-        description: 'Update an existing book',
+        description: 'Update book',
         inputSchema: {
             type: 'object',
             properties: {
-                book_id: { 
-                    type: 'integer', 
-                    description: 'The ID of the book to update' 
+                book_id: {
+                    type: 'integer',
+                    description: 'Book ID'
                 },
-                title: { 
-                    type: 'string', 
-                    description: 'Book title' 
+                title: {
+                    type: 'string',
+                    description: 'Title'
                 },
-                book_number: { 
-                    type: 'integer', 
-                    description: 'Position in the series' 
+                book_number: {
+                    type: 'integer',
+                    description: 'Series position'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Book status'
+                    description: 'Status'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count for the book'
+                    description: 'Target word count'
                 },
                 actual_word_count: {
                     type: 'integer',
-                    description: 'Current word count of the book'
+                    description: 'Current word count'
                 },
-                publication_year: { 
-                    type: 'integer', 
-                    description: 'Year of publication' 
+                publication_year: {
+                    type: 'integer',
+                    description: 'Pub year'
                 },
-                isbn: { 
-                    type: 'string', 
-                    description: 'ISBN number' 
+                isbn: {
+                    type: 'string',
+                    description: 'ISBN'
                 },
-                page_count: { 
-                    type: 'integer', 
-                    description: 'Number of pages' 
+                page_count: {
+                    type: 'integer',
+                    description: 'Pages'
                 },
-                description: { 
-                    type: 'string', 
-                    description: 'Book description/summary' 
+                description: {
+                    type: 'string',
+                    description: 'Description'
                 },
                 cover_image_url: {
                     type: 'string',
-                    description: 'URL to book cover image'
+                    description: 'Cover URL'
                 },
                 genre_names: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre names for this specific book'
+                    description: 'Genre names'
                 }
             },
             required: ['book_id']
@@ -173,17 +173,17 @@ export const bookToolsSchema = [
     },
     {
         name: 'delete_book',
-        description: 'Delete a book and all its chapters/scenes',
+        description: 'Delete book & chapters/scenes',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'The ID of the book to delete'
+                    description: 'Book ID'
                 },
                 confirm_deletion: {
                     type: 'boolean',
-                    description: 'Must be true to confirm deletion'
+                    description: 'Confirm (must be true)'
                 }
             },
             required: ['book_id', 'confirm_deletion']
@@ -197,63 +197,63 @@ export const bookToolsSchema = [
 export const chapterToolsSchema = [
     {
         name: 'create_chapter',
-        description: 'Create a new chapter within a book',
+        description: 'Create chapter',
         inputSchema: {
             type: 'object',
             properties: {
-                book_id: { 
-                    type: 'integer', 
-                    description: 'ID of the book this chapter belongs to' 
+                book_id: {
+                    type: 'integer',
+                    description: 'Book ID'
                 },
-                chapter_number: { 
-                    type: 'integer', 
-                    description: 'Chapter number within the book' 
+                chapter_number: {
+                    type: 'integer',
+                    description: 'Chapter # in book'
                 },
-                title: { 
-                    type: 'string', 
-                    description: 'Chapter title' 
+                title: {
+                    type: 'string',
+                    description: 'Title'
                 },
-                subtitle: { 
-                    type: 'string', 
-                    description: 'Optional chapter subtitle' 
+                subtitle: {
+                    type: 'string',
+                    description: 'Subtitle'
                 },
-                summary: { 
-                    type: 'string', 
-                    description: 'Brief chapter summary' 
+                summary: {
+                    type: 'string',
+                    description: 'Summary'
                 },
-                target_word_count: { 
-                    type: 'integer', 
-                    description: 'Target word count for this chapter' 
+                target_word_count: {
+                    type: 'integer',
+                    description: 'Target word count'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
                     default: 'planned',
-                    description: 'Chapter writing status'
+                    description: 'Writing status'
                 },
-                pov_character_id: { 
-                    type: 'integer', 
-                    description: 'ID of the POV character for this chapter' 
+                pov_character_id: {
+                    type: 'integer',
+                    description: 'POV character ID'
                 },
-                primary_location: { 
-                    type: 'string', 
-                    description: 'Main setting for this chapter' 
+                primary_location: {
+                    type: 'string',
+                    description: 'Main setting'
                 },
-                story_time_start: { 
-                    type: 'string', 
-                    description: 'When chapter events begin (e.g., "Day 1, 3pm")' 
+                story_time_start: {
+                    type: 'string',
+                    description: 'Start time (e.g., "Day 1, 3pm")'
                 },
-                story_time_end: { 
-                    type: 'string', 
-                    description: 'When chapter events end' 
+                story_time_end: {
+                    type: 'string',
+                    description: 'End time'
                 },
-                story_duration: { 
-                    type: 'string', 
-                    description: 'How long chapter events take (e.g., "2 hours")' 
+                story_duration: {
+                    type: 'string',
+                    description: 'Duration (e.g., "2 hours")'
                 },
-                author_notes: { 
-                    type: 'string', 
-                    description: 'Planning notes and reminders' 
+                author_notes: {
+                    type: 'string',
+                    description: 'Planning notes'
                 }
             },
             required: ['book_id', 'chapter_number']
@@ -261,66 +261,66 @@ export const chapterToolsSchema = [
     },
     {
         name: 'update_chapter',
-        description: 'Update an existing chapter',
+        description: 'Update chapter',
         inputSchema: {
             type: 'object',
             properties: {
-                chapter_id: { 
-                    type: 'integer', 
-                    description: 'ID of the chapter to update' 
+                chapter_id: {
+                    type: 'integer',
+                    description: 'Chapter ID'
                 },
-                title: { 
-                    type: 'string', 
-                    description: 'Chapter title' 
+                title: {
+                    type: 'string',
+                    description: 'Title'
                 },
-                subtitle: { 
-                    type: 'string', 
-                    description: 'Chapter subtitle' 
+                subtitle: {
+                    type: 'string',
+                    description: 'Subtitle'
                 },
-                summary: { 
-                    type: 'string', 
-                    description: 'Chapter summary' 
+                summary: {
+                    type: 'string',
+                    description: 'Summary'
                 },
-                word_count: { 
-                    type: 'integer', 
-                    description: 'Current word count' 
+                word_count: {
+                    type: 'integer',
+                    description: 'Current word count'
                 },
-                target_word_count: { 
-                    type: 'integer', 
-                    description: 'Target word count' 
+                target_word_count: {
+                    type: 'integer',
+                    description: 'Target word count'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Chapter writing status'
+                    description: 'Writing status'
                 },
-                pov_character_id: { 
-                    type: 'integer', 
-                    description: 'POV character ID' 
+                pov_character_id: {
+                    type: 'integer',
+                    description: 'POV character ID'
                 },
-                primary_location: { 
-                    type: 'string', 
-                    description: 'Main setting for this chapter' 
+                primary_location: {
+                    type: 'string',
+                    description: 'Main setting'
                 },
-                story_time_start: { 
-                    type: 'string', 
-                    description: 'Chapter start time' 
+                story_time_start: {
+                    type: 'string',
+                    description: 'Start time'
                 },
-                story_time_end: { 
-                    type: 'string', 
-                    description: 'Chapter end time' 
+                story_time_end: {
+                    type: 'string',
+                    description: 'End time'
                 },
-                story_duration: { 
-                    type: 'string', 
-                    description: 'Chapter duration' 
+                story_duration: {
+                    type: 'string',
+                    description: 'Duration'
                 },
-                author_notes: { 
-                    type: 'string', 
-                    description: 'Author notes' 
+                author_notes: {
+                    type: 'string',
+                    description: 'Author notes'
                 },
-                writing_notes: { 
-                    type: 'string', 
-                    description: 'Writing process notes' 
+                writing_notes: {
+                    type: 'string',
+                    description: 'Writing notes'
                 }
             },
             required: ['chapter_id']
@@ -328,23 +328,23 @@ export const chapterToolsSchema = [
     },
     {
         name: 'get_chapter',
-        description: 'Get detailed information about a specific chapter',
+        description: 'Get chapter details',
         inputSchema: {
             type: 'object',
             properties: {
-                chapter_id: { 
-                    type: 'integer', 
-                    description: 'ID of the chapter' 
+                chapter_id: {
+                    type: 'integer',
+                    description: 'Chapter ID'
                 },
                 include_scenes: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include scene information'
+                    description: 'Include scenes'
                 },
                 include_characters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include character presence information'
+                    description: 'Include character presence'
                 }
             },
             required: ['chapter_id']
@@ -352,23 +352,23 @@ export const chapterToolsSchema = [
     },
     {
         name: 'list_chapters',
-        description: 'List all chapters in a book',
+        description: 'List chapters',
         inputSchema: {
             type: 'object',
             properties: {
-                book_id: { 
-                    type: 'integer', 
-                    description: 'ID of the book' 
+                book_id: {
+                    type: 'integer',
+                    description: 'Book ID'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Filter by chapter status (optional)'
+                    description: 'Status filter'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include word count and scene statistics'
+                    description: 'Include stats'
                 }
             },
             required: ['book_id']
@@ -376,17 +376,17 @@ export const chapterToolsSchema = [
     },
     {
         name: 'delete_chapter',
-        description: 'Delete a chapter and all its scenes',
+        description: 'Delete chapter & scenes',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter to delete'
+                    description: 'Chapter ID'
                 },
                 confirm_deletion: {
                     type: 'boolean',
-                    description: 'Must be true to confirm deletion'
+                    description: 'Confirm (must be true)'
                 }
             },
             required: ['chapter_id', 'confirm_deletion']
@@ -427,85 +427,85 @@ export const chapterToolsSchema = [
 export const sceneToolsSchema = [
     {
         name: 'create_scene',
-        description: 'Create a new scene within a chapter',
+        description: 'Create scene',
         inputSchema: {
             type: 'object',
             properties: {
-                chapter_id: { 
-                    type: 'integer', 
-                    description: 'ID of the chapter this scene belongs to' 
+                chapter_id: {
+                    type: 'integer',
+                    description: 'Chapter ID'
                 },
-                scene_number: { 
-                    type: 'integer', 
-                    description: 'Scene number within the chapter' 
+                scene_number: {
+                    type: 'integer',
+                    description: 'Scene # in chapter'
                 },
-                scene_title: { 
-                    type: 'string', 
-                    description: 'Optional scene title or name' 
+                scene_title: {
+                    type: 'string',
+                    description: 'Title'
                 },
-                scene_purpose: { 
-                    type: 'string', 
+                scene_purpose: {
+                    type: 'string',
                     enum: ['action', 'dialogue', 'description', 'transition', 'exposition', 'conflict', 'resolution'],
-                    description: 'Primary purpose of this scene' 
+                    description: 'Purpose'
                 },
-                scene_type: { 
-                    type: 'string', 
+                scene_type: {
+                    type: 'string',
                     enum: ['dramatic', 'comedic', 'action', 'romance', 'mystery', 'horror', 'slice_of_life'],
-                    description: 'Emotional tone or genre type of scene' 
+                    description: 'Tone/genre'
                 },
-                location: { 
-                    type: 'string', 
-                    description: 'Where this scene takes place' 
+                location: {
+                    type: 'string',
+                    description: 'Location'
                 },
-                time_of_day: { 
-                    type: 'string', 
-                    description: 'Time when scene occurs (morning, afternoon, night, etc.)' 
+                time_of_day: {
+                    type: 'string',
+                    description: 'Time (morning, afternoon, night, etc.)'
                 },
-                duration: { 
-                    type: 'string', 
-                    description: 'How long this scene lasts (5 minutes, 2 hours, etc.)' 
+                duration: {
+                    type: 'string',
+                    description: 'Duration (5 minutes, 2 hours, etc.)'
                 },
-                summary: { 
-                    type: 'string', 
-                    description: 'Brief summary of what happens in this scene' 
+                summary: {
+                    type: 'string',
+                    description: 'Summary'
                 },
-                pov_character_id: { 
-                    type: 'integer', 
-                    description: 'ID of the POV character for this scene' 
+                pov_character_id: {
+                    type: 'integer',
+                    description: 'POV character ID'
                 },
                 scene_participants: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Array of character IDs present in this scene'
+                    description: 'Character IDs in scene'
                 },
                 writing_status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
                     default: 'planned',
-                    description: 'Writing progress status for this scene'
+                    description: 'Writing status'
                 },
-                target_word_count: { 
-                    type: 'integer', 
-                    description: 'Target word count for this scene' 
+                target_word_count: {
+                    type: 'integer',
+                    description: 'Target word count'
                 },
                 intensity_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Scene intensity for pacing (1=low, 10=maximum)'
+                    description: 'Intensity (1=low, 10=max)'
                 },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Tags for scene elements (e.g., tropes, kinks, themes, moods)'
+                    description: 'Element tags (tropes, themes, moods)'
                 },
                 implementation_notes: {
                     type: 'string',
-                    description: 'Detailed notes about how this scene implements specific elements or requirements'
+                    description: 'Implementation notes'
                 },
-                notes: { 
-                    type: 'string', 
-                    description: 'General author notes and reminders for this scene' 
+                notes: {
+                    type: 'string',
+                    description: 'Author notes'
                 }
             },
             required: ['chapter_id', 'scene_number']
@@ -513,60 +513,60 @@ export const sceneToolsSchema = [
     },
     {
         name: 'update_scene',
-        description: 'Update an existing scene',
+        description: 'Update scene',
         inputSchema: {
             type: 'object',
             properties: {
-                scene_id: { 
-                    type: 'integer', 
-                    description: 'ID of the scene to update' 
+                scene_id: {
+                    type: 'integer',
+                    description: 'Scene ID'
                 },
-                scene_title: { 
-                    type: 'string', 
-                    description: 'Scene title' 
+                scene_title: {
+                    type: 'string',
+                    description: 'Title'
                 },
-                scene_purpose: { 
-                    type: 'string', 
+                scene_purpose: {
+                    type: 'string',
                     enum: ['action', 'dialogue', 'description', 'transition', 'exposition', 'conflict', 'resolution'],
-                    description: 'Primary purpose of this scene' 
+                    description: 'Purpose'
                 },
-                scene_type: { 
-                    type: 'string', 
+                scene_type: {
+                    type: 'string',
                     enum: ['dramatic', 'comedic', 'action', 'romance', 'mystery', 'horror', 'slice_of_life'],
-                    description: 'Emotional tone or genre type of scene' 
+                    description: 'Tone/genre'
                 },
-                location: { 
-                    type: 'string', 
-                    description: 'Scene location' 
+                location: {
+                    type: 'string',
+                    description: 'Location'
                 },
-                time_of_day: { 
-                    type: 'string', 
-                    description: 'Time of day' 
+                time_of_day: {
+                    type: 'string',
+                    description: 'Time of day'
                 },
-                duration: { 
-                    type: 'string', 
-                    description: 'Scene duration' 
+                duration: {
+                    type: 'string',
+                    description: 'Duration'
                 },
-                summary: { 
-                    type: 'string', 
-                    description: 'Scene summary' 
+                summary: {
+                    type: 'string',
+                    description: 'Summary'
                 },
-                word_count: { 
-                    type: 'integer', 
-                    description: 'Current word count for this scene' 
+                word_count: {
+                    type: 'integer',
+                    description: 'Current word count'
                 },
-                target_word_count: { 
-                    type: 'integer', 
-                    description: 'Target word count' 
+                target_word_count: {
+                    type: 'integer',
+                    description: 'Target word count'
                 },
-                pov_character_id: { 
-                    type: 'integer', 
-                    description: 'POV character ID' 
+                pov_character_id: {
+                    type: 'integer',
+                    description: 'POV character ID'
                 },
                 scene_participants: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Character IDs present in scene'
+                    description: 'Character IDs in scene'
                 },
                 writing_status: {
                     type: 'string',
@@ -577,20 +577,20 @@ export const sceneToolsSchema = [
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Scene intensity for pacing (1=low, 10=maximum)'
+                    description: 'Intensity (1=low, 10=max)'
                 },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Tags for scene elements (e.g., tropes, kinks, themes, moods)'
+                    description: 'Element tags (tropes, themes, moods)'
                 },
                 implementation_notes: {
                     type: 'string',
-                    description: 'Detailed notes about how this scene implements specific elements or requirements'
+                    description: 'Implementation notes'
                 },
-                notes: { 
-                    type: 'string', 
-                    description: 'General scene notes' 
+                notes: {
+                    type: 'string',
+                    description: 'Scene notes'
                 }
             },
             required: ['scene_id']
@@ -598,18 +598,18 @@ export const sceneToolsSchema = [
     },
     {
         name: 'get_scene',
-        description: 'Get detailed information about a specific scene',
+        description: 'Get scene details',
         inputSchema: {
             type: 'object',
             properties: {
-                scene_id: { 
-                    type: 'integer', 
-                    description: 'ID of the scene' 
+                scene_id: {
+                    type: 'integer',
+                    description: 'Scene ID'
                 },
                 include_characters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include character participant details'
+                    description: 'Include character details'
                 }
             },
             required: ['scene_id']
@@ -617,28 +617,28 @@ export const sceneToolsSchema = [
     },
     {
         name: 'list_scenes',
-        description: 'List all scenes in a chapter',
+        description: 'List scenes',
         inputSchema: {
             type: 'object',
             properties: {
-                chapter_id: { 
-                    type: 'integer', 
-                    description: 'ID of the chapter' 
+                chapter_id: {
+                    type: 'integer',
+                    description: 'Chapter ID'
                 },
                 scene_type: {
                     type: 'string',
                     enum: ['dramatic', 'comedic', 'action', 'romance', 'mystery', 'horror', 'slice_of_life'],
-                    description: 'Filter by scene type (optional)'
+                    description: 'Scene type filter'
                 },
                 writing_status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Filter by writing status (optional)'
+                    description: 'Status filter'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include word count statistics'
+                    description: 'Include stats'
                 },
                 intensity_filter: {
                     type: 'object',
@@ -646,12 +646,12 @@ export const sceneToolsSchema = [
                         min_intensity: { type: 'integer', minimum: 1, maximum: 10 },
                         max_intensity: { type: 'integer', minimum: 1, maximum: 10 }
                     },
-                    description: 'Filter by intensity level range'
+                    description: 'Intensity range filter'
                 },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Filter scenes containing specific elements'
+                    description: 'Element filter'
                 }
             },
             required: ['chapter_id']
@@ -659,17 +659,17 @@ export const sceneToolsSchema = [
     },
     {
         name: 'delete_scene',
-        description: 'Delete a scene',
+        description: 'Delete scene',
         inputSchema: {
             type: 'object',
             properties: {
                 scene_id: {
                     type: 'integer',
-                    description: 'ID of the scene to delete'
+                    description: 'Scene ID'
                 },
                 confirm_deletion: {
                     type: 'boolean',
-                    description: 'Must be true to confirm deletion'
+                    description: 'Confirm (must be true)'
                 }
             },
             required: ['scene_id', 'confirm_deletion']
@@ -677,13 +677,13 @@ export const sceneToolsSchema = [
     },
     {
         name: 'reorder_scenes',
-        description: 'Reorder scenes within a chapter by updating scene numbers',
+        description: 'Reorder scenes',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter'
+                    description: 'Chapter ID'
                 },
                 scene_order: {
                     type: 'array',
@@ -695,7 +695,7 @@ export const sceneToolsSchema = [
                         },
                         required: ['scene_id', 'new_scene_number']
                     },
-                    description: 'Array of scene IDs and their new scene numbers'
+                    description: 'Scene IDs w/ new numbers'
                 }
             },
             required: ['chapter_id', 'scene_order']
@@ -703,24 +703,24 @@ export const sceneToolsSchema = [
     },
     {
         name: 'analyze_scene_flow',
-        description: 'Analyze the flow and pacing between scenes in a chapter',
+        description: 'Analyze scene flow & pacing',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter to analyze'
+                    description: 'Chapter ID'
                 },
                 analysis_type: {
                     type: 'string',
                     enum: ['intensity_flow', 'element_distribution', 'character_presence', 'scene_balance'],
                     default: 'intensity_flow',
-                    description: 'Type of analysis to perform'
+                    description: 'Analysis type'
                 },
                 include_suggestions: {
                     type: 'boolean',
                     default: true,
-                    description: 'Include improvement suggestions'
+                    description: 'Include suggestions'
                 }
             },
             required: ['chapter_id']
@@ -735,23 +735,23 @@ export const sceneToolsSchema = [
 export const analysisToolsSchema = [
     {
         name: 'get_book_structure',
-        description: 'Get comprehensive book structure with chapters and scenes',
+        description: 'Get book structure',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'ID of the book to analyze'
+                    description: 'Book ID'
                 },
                 include_scene_details: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include detailed scene information'
+                    description: 'Include scene details'
                 },
                 include_character_info: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include character presence information'
+                    description: 'Include character presence'
                 }
             },
             required: ['book_id']
@@ -759,23 +759,23 @@ export const analysisToolsSchema = [
     },
     {
         name: 'analyze_book_progress',
-        description: 'Analyze writing progress and completion status for a book',
+        description: 'Analyze writing progress',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'ID of the book to analyze'
+                    description: 'Book ID'
                 },
                 include_projections: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include completion time projections'
+                    description: 'Include completion projections'
                 },
                 include_recommendations: {
                     type: 'boolean',
                     default: true,
-                    description: 'Include writing recommendations'
+                    description: 'Include recommendations'
                 }
             },
             required: ['book_id']
@@ -783,34 +783,34 @@ export const analysisToolsSchema = [
     },
     {
         name: 'validate_book_consistency',
-        description: 'Check for structural and consistency issues in a book',
+        description: 'Check consistency issues',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'ID of the book to validate'
+                    description: 'Book ID'
                 },
                 check_chapter_numbering: {
                     type: 'boolean',
                     default: true,
-                    description: 'Check for chapter numbering issues'
+                    description: 'Check chapter numbering'
                 },
                 check_word_counts: {
                     type: 'boolean',
                     default: true,
-                    description: 'Validate word count consistency'
+                    description: 'Check word counts'
                 },
                 check_character_continuity: {
                     type: 'boolean',
                     default: false,
-                    description: 'Check character presence continuity (requires character server)'
+                    description: 'Check character continuity (needs character server)'
                 },
                 severity_level: {
                     type: 'string',
                     enum: ['all', 'warnings_and_errors', 'errors_only'],
                     default: 'all',
-                    description: 'Level of issues to report'
+                    description: 'Issue severity filter'
                 }
             },
             required: ['book_id']

--- a/src/mcps/book-server/schemas/chapter-planning-schemas.js
+++ b/src/mcps/book-server/schemas/chapter-planning-schemas.js
@@ -9,62 +9,62 @@
 export const chapterPlanningSchemas = {
     create_chapter: {
         name: 'create_chapter',
-        description: 'Create a new chapter within a book',
+        description: 'Create chapter',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'ID of the book this chapter belongs to'
+                    description: 'Book ID'
                 },
                 chapter_number: {
                     type: 'integer',
-                    description: 'Chapter number within the book'
+                    description: 'Chapter # in book'
                 },
                 title: {
                     type: 'string',
-                    description: 'Chapter title'
+                    description: 'Title'
                 },
                 subtitle: {
                     type: 'string',
-                    description: 'Optional chapter subtitle'
+                    description: 'Subtitle'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Brief chapter summary'
+                    description: 'Summary'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count for this chapter'
+                    description: 'Target word count'
                 },
                 status: {
                     type: 'string',
                     default: 'planned',
-                    description: 'Chapter writing status (use get_available_options with option_type="writing_statuses")'
+                    description: 'Writing status (use get_available_options w/ option_type="writing_statuses")'
                 },
                 pov_character_id: {
                     type: 'integer',
-                    description: 'ID of the POV character for this chapter'
+                    description: 'POV character ID'
                 },
                 primary_location: {
                     type: 'string',
-                    description: 'Main setting for this chapter'
+                    description: 'Main setting'
                 },
                 story_time_start: {
                     type: 'string',
-                    description: 'When chapter events begin (e.g., "Day 1, 3pm")'
+                    description: 'Start time (e.g., "Day 1, 3pm")'
                 },
                 story_time_end: {
                     type: 'string',
-                    description: 'When chapter events end'
+                    description: 'End time'
                 },
                 story_duration: {
                     type: 'string',
-                    description: 'How long chapter events take (e.g., "2 hours")'
+                    description: 'Duration (e.g., "2 hours")'
                 },
                 author_notes: {
                     type: 'string',
-                    description: 'Planning notes and reminders'
+                    description: 'Planning notes'
                 }
             },
             required: ['book_id', 'chapter_number']
@@ -73,25 +73,25 @@ export const chapterPlanningSchemas = {
 
     update_chapter: {
         name: 'update_chapter',
-        description: 'Update an existing chapter',
+        description: 'Update chapter',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter to update'
+                    description: 'Chapter ID'
                 },
                 title: {
                     type: 'string',
-                    description: 'Chapter title'
+                    description: 'Title'
                 },
                 subtitle: {
                     type: 'string',
-                    description: 'Chapter subtitle'
+                    description: 'Subtitle'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Chapter summary'
+                    description: 'Summary'
                 },
                 word_count: {
                     type: 'integer',
@@ -103,7 +103,7 @@ export const chapterPlanningSchemas = {
                 },
                 status: {
                     type: 'string',
-                    description: 'Chapter writing status (use get_available_options with option_type="writing_statuses")'
+                    description: 'Writing status (use get_available_options w/ option_type="writing_statuses")'
                 },
                 pov_character_id: {
                     type: 'integer',
@@ -111,19 +111,19 @@ export const chapterPlanningSchemas = {
                 },
                 primary_location: {
                     type: 'string',
-                    description: 'Main setting for this chapter'
+                    description: 'Main setting'
                 },
                 story_time_start: {
                     type: 'string',
-                    description: 'Chapter start time'
+                    description: 'Start time'
                 },
                 story_time_end: {
                     type: 'string',
-                    description: 'Chapter end time'
+                    description: 'End time'
                 },
                 story_duration: {
                     type: 'string',
-                    description: 'Chapter duration'
+                    description: 'Duration'
                 },
                 author_notes: {
                     type: 'string',
@@ -131,7 +131,7 @@ export const chapterPlanningSchemas = {
                 },
                 writing_notes: {
                     type: 'string',
-                    description: 'Writing process notes'
+                    description: 'Writing notes'
                 }
             },
             required: ['chapter_id']
@@ -140,23 +140,23 @@ export const chapterPlanningSchemas = {
 
     get_chapter: {
         name: 'get_chapter',
-        description: 'Get detailed information about a specific chapter',
+        description: 'Get chapter details',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter'
+                    description: 'Chapter ID'
                 },
                 include_scenes: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include scene information'
+                    description: 'Include scenes'
                 },
                 include_characters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include character presence information'
+                    description: 'Include character presence'
                 }
             },
             required: ['chapter_id']
@@ -165,22 +165,22 @@ export const chapterPlanningSchemas = {
 
     list_chapters: {
         name: 'list_chapters',
-        description: 'List all chapters in a book',
+        description: 'List chapters',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'ID of the book'
+                    description: 'Book ID'
                 },
                 status: {
                     type: 'string',
-                    description: 'Filter by chapter status (optional, use get_available_options with option_type="writing_statuses")'
+                    description: 'Status filter (use get_available_options w/ option_type="writing_statuses")'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include word count and scene statistics'
+                    description: 'Include stats'
                 }
             },
             required: ['book_id']
@@ -189,17 +189,17 @@ export const chapterPlanningSchemas = {
 
     delete_chapter: {
         name: 'delete_chapter',
-        description: 'Delete a chapter and all its scenes',
+        description: 'Delete chapter & scenes',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter to delete'
+                    description: 'Chapter ID'
                 },
                 confirm_deletion: {
                     type: 'boolean',
-                    description: 'Must be true to confirm deletion'
+                    description: 'Confirm (must be true)'
                 }
             },
             required: ['chapter_id', 'confirm_deletion']

--- a/src/mcps/book-server/schemas/revision-schemas.js
+++ b/src/mcps/book-server/schemas/revision-schemas.js
@@ -10,18 +10,18 @@ export const revisionSchemas = {
     // Book-level tools for final checks
     get_book: {
         name: 'get_book',
-        description: 'Get detailed information about a specific book',
+        description: 'Get book details',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'The ID of the book'
+                    description: 'Book ID'
                 },
                 include_chapters: {
                     type: 'boolean',
                     default: true,  // Changed default to true for revision phase
-                    description: 'Include chapter summary information'
+                    description: 'Include chapters'
                 }
             },
             required: ['book_id']
@@ -30,26 +30,26 @@ export const revisionSchemas = {
 
     update_book: {
         name: 'update_book',
-        description: 'Update book status and metadata after revision',
+        description: 'Update book post-revision',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'The ID of the book to update'
+                    description: 'Book ID'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'draft', 'editing', 'final', 'published'],
-                    description: 'Book status'
+                    description: 'Status'
                 },
                 actual_word_count: {
                     type: 'integer',
-                    description: 'Current word count of the book'
+                    description: 'Current word count'
                 },
                 description: {
                     type: 'string',
-                    description: 'Book description/summary'
+                    description: 'Description'
                 }
             },
             required: ['book_id']
@@ -59,23 +59,23 @@ export const revisionSchemas = {
     // Chapter tools for revision
     get_chapter: {
         name: 'get_chapter',
-        description: 'Get detailed information about a specific chapter',
+        description: 'Get chapter details',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter'
+                    description: 'Chapter ID'
                 },
                 include_scenes: {
                     type: 'boolean',
                     default: true,  // Changed default to true for revision phase
-                    description: 'Include scene information'
+                    description: 'Include scenes'
                 },
                 include_characters: {
                     type: 'boolean',
                     default: true,  // Changed default to true for revision phase
-                    description: 'Include character presence information'
+                    description: 'Include character presence'
                 }
             },
             required: ['chapter_id']
@@ -84,21 +84,21 @@ export const revisionSchemas = {
 
     update_chapter: {
         name: 'update_chapter',
-        description: 'Update chapter after revision',
+        description: 'Update chapter post-revision',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter to update'
+                    description: 'Chapter ID'
                 },
                 title: {
                     type: 'string',
-                    description: 'Chapter title'
+                    description: 'Title'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Chapter summary'
+                    description: 'Summary'
                 },
                 word_count: {
                     type: 'integer',
@@ -107,11 +107,11 @@ export const revisionSchemas = {
                 status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Chapter writing status'
+                    description: 'Writing status'
                 },
                 writing_notes: {
                     type: 'string',
-                    description: 'Writing process notes'
+                    description: 'Writing notes'
                 }
             },
             required: ['chapter_id']
@@ -120,23 +120,23 @@ export const revisionSchemas = {
 
     list_chapters: {
         name: 'list_chapters',
-        description: 'List all chapters in a book',
+        description: 'List chapters',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: {
                     type: 'integer',
-                    description: 'ID of the book'
+                    description: 'Book ID'
                 },
                 status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Filter by chapter status (optional)'
+                    description: 'Status filter'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: true,  // Changed default to true for revision phase
-                    description: 'Include word count and scene statistics'
+                    description: 'Include stats'
                 }
             },
             required: ['book_id']
@@ -146,18 +146,18 @@ export const revisionSchemas = {
     // Scene tools for revision
     get_scene: {
         name: 'get_scene',
-        description: 'Get detailed information about a specific scene',
+        description: 'Get scene details',
         inputSchema: {
             type: 'object',
             properties: {
                 scene_id: {
                     type: 'integer',
-                    description: 'ID of the scene'
+                    description: 'Scene ID'
                 },
                 include_characters: {
                     type: 'boolean',
                     default: true,  // Changed default to true for revision phase
-                    description: 'Include character participant details'
+                    description: 'Include character details'
                 }
             },
             required: ['scene_id']
@@ -166,21 +166,21 @@ export const revisionSchemas = {
 
     update_scene: {
         name: 'update_scene',
-        description: 'Update scene after revision',
+        description: 'Update scene post-revision',
         inputSchema: {
             type: 'object',
             properties: {
                 scene_id: {
                     type: 'integer',
-                    description: 'ID of the scene to update'
+                    description: 'Scene ID'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Scene summary'
+                    description: 'Summary'
                 },
                 word_count: {
                     type: 'integer',
-                    description: 'Current word count for this scene'
+                    description: 'Current word count'
                 },
                 writing_status: {
                     type: 'string',
@@ -189,7 +189,7 @@ export const revisionSchemas = {
                 },
                 notes: {
                     type: 'string',
-                    description: 'General scene notes'
+                    description: 'Scene notes'
                 }
             },
             required: ['scene_id']
@@ -198,23 +198,23 @@ export const revisionSchemas = {
 
     list_scenes: {
         name: 'list_scenes',
-        description: 'List all scenes in a chapter',
+        description: 'List scenes',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter'
+                    description: 'Chapter ID'
                 },
                 writing_status: {
                     type: 'string',
                     enum: ['planned', 'outlined', 'drafted', 'revised', 'final'],
-                    description: 'Filter by writing status (optional)'
+                    description: 'Status filter'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: true,  // Changed default to true for revision phase
-                    description: 'Include word count statistics'
+                    description: 'Include stats'
                 }
             },
             required: ['chapter_id']
@@ -223,17 +223,17 @@ export const revisionSchemas = {
 
     delete_scene: {
         name: 'delete_scene',
-        description: 'Delete a scene during revision',
+        description: 'Delete scene',
         inputSchema: {
             type: 'object',
             properties: {
                 scene_id: {
                     type: 'integer',
-                    description: 'ID of the scene to delete'
+                    description: 'Scene ID'
                 },
                 confirm_deletion: {
                     type: 'boolean',
-                    description: 'Must be true to confirm deletion'
+                    description: 'Confirm (must be true)'
                 }
             },
             required: ['scene_id', 'confirm_deletion']
@@ -242,24 +242,24 @@ export const revisionSchemas = {
 
     analyze_scene_flow: {
         name: 'analyze_scene_flow',
-        description: 'Analyze the flow and pacing between scenes in a chapter',
+        description: 'Analyze scene flow & pacing',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter to analyze'
+                    description: 'Chapter ID'
                 },
                 analysis_type: {
                     type: 'string',
                     enum: ['intensity_flow', 'element_distribution', 'character_presence', 'scene_balance'],
                     default: 'intensity_flow',
-                    description: 'Type of analysis to perform'
+                    description: 'Analysis type'
                 },
                 include_suggestions: {
                     type: 'boolean',
                     default: true,
-                    description: 'Include improvement suggestions'
+                    description: 'Include suggestions'
                 }
             },
             required: ['chapter_id']

--- a/src/mcps/book-server/schemas/scene-writing-schemas.js
+++ b/src/mcps/book-server/schemas/scene-writing-schemas.js
@@ -9,91 +9,91 @@
 export const sceneWritingSchemas = {
     create_scene: {
         name: 'create_scene',
-        description: 'Create a new scene within a chapter',
+        description: 'Create scene',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter this scene belongs to'
+                    description: 'Chapter ID'
                 },
                 scene_number: {
                     type: 'integer',
-                    description: 'Scene number within the chapter'
+                    description: 'Scene # in chapter'
                 },
                 scene_title: {
                     type: 'string',
-                    description: 'Optional scene title or name'
+                    description: 'Title'
                 },
                 scene_purpose: {
                     type: 'string',
-                    description: 'Primary purpose of this scene (use get_available_options with option_type="scene_purposes")'
+                    description: 'Purpose (use get_available_options w/ option_type="scene_purposes")'
                 },
                 scene_type: {
                     type: 'string',
-                    description: 'Emotional tone or genre type of scene (use get_available_options with option_type="scene_types")'
+                    description: 'Tone/genre (use get_available_options w/ option_type="scene_types")'
                 },
                 location: {
                     type: 'string',
-                    description: 'Where this scene takes place'
+                    description: 'Location'
                 },
                 time_of_day: {
                     type: 'string',
-                    description: 'Time when scene occurs (morning, afternoon, night, etc.)'
+                    description: 'Time (morning, afternoon, night, etc.)'
                 },
                 duration: {
                     type: 'string',
-                    description: 'How long this scene lasts (5 minutes, 2 hours, etc.)'
+                    description: 'Duration (5 minutes, 2 hours, etc.)'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Brief summary of what happens in this scene'
+                    description: 'Summary'
                 },
                 pov_character_id: {
                     type: 'integer',
-                    description: 'ID of the POV character for this scene'
+                    description: 'POV character ID'
                 },
                 scene_participants: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Array of character IDs present in this scene'
+                    description: 'Character IDs in scene'
                 },
                 writing_status: {
                     type: 'string',
                     default: 'planned',
-                    description: 'Writing progress status for this scene (use get_available_options with option_type="writing_statuses")'
+                    description: 'Writing status (use get_available_options w/ option_type="writing_statuses")'
                 },
                 target_word_count: {
                     type: 'integer',
-                    description: 'Target word count for this scene'
+                    description: 'Target word count'
                 },
                 intensity_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Scene intensity for pacing (1=low, 10=maximum)'
+                    description: 'Intensity (1=low, 10=max)'
                 },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Tags for scene elements (e.g., tropes, kinks, themes, moods)'
+                    description: 'Element tags (tropes, themes, moods)'
                 },
                 notes: {
                     type: 'string',
-                    description: 'Quick notes and reminders for this scene'
+                    description: 'Quick notes'
                 },
                 scene_outline: {
                     type: 'string',
-                    description: 'Detailed scene planning, beat sheet, and structural notes'
+                    description: 'Scene planning & structure'
                 },
                 scene_content: {
                     type: 'string',
-                    description: 'The actual written content of the scene'
+                    description: 'Written content'
                 },
                 scene_revisions: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Array of previous versions for tracking major revisions'
+                    description: 'Previous versions'
                 }
             },
             required: ['chapter_id', 'scene_number']
@@ -102,29 +102,29 @@ export const sceneWritingSchemas = {
 
     update_scene: {
         name: 'update_scene',
-        description: 'Update an existing scene',
+        description: 'Update scene',
         inputSchema: {
             type: 'object',
             properties: {
                 scene_id: {
                     type: 'integer',
-                    description: 'ID of the scene to update'
+                    description: 'Scene ID'
                 },
                 scene_title: {
                     type: 'string',
-                    description: 'Scene title'
+                    description: 'Title'
                 },
                 scene_purpose: {
                     type: 'string',
-                    description: 'Primary purpose of this scene (use get_available_options with option_type="scene_purposes")'
+                    description: 'Purpose (use get_available_options w/ option_type="scene_purposes")'
                 },
                 scene_type: {
                     type: 'string',
-                    description: 'Emotional tone or genre type of scene (use get_available_options with option_type="scene_types")'
+                    description: 'Tone/genre (use get_available_options w/ option_type="scene_types")'
                 },
                 location: {
                     type: 'string',
-                    description: 'Scene location'
+                    description: 'Location'
                 },
                 time_of_day: {
                     type: 'string',
@@ -132,15 +132,15 @@ export const sceneWritingSchemas = {
                 },
                 duration: {
                     type: 'string',
-                    description: 'Scene duration'
+                    description: 'Duration'
                 },
                 summary: {
                     type: 'string',
-                    description: 'Scene summary'
+                    description: 'Summary'
                 },
                 word_count: {
                     type: 'integer',
-                    description: 'Current word count for this scene'
+                    description: 'Current word count'
                 },
                 target_word_count: {
                     type: 'integer',
@@ -153,39 +153,39 @@ export const sceneWritingSchemas = {
                 scene_participants: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Character IDs present in scene'
+                    description: 'Character IDs in scene'
                 },
                 writing_status: {
                     type: 'string',
-                    description: 'Writing status (use get_available_options with option_type="writing_statuses")'
+                    description: 'Writing status (use get_available_options w/ option_type="writing_statuses")'
                 },
                 intensity_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Scene intensity for pacing (1=low, 10=maximum)'
+                    description: 'Intensity (1=low, 10=max)'
                 },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Tags for scene elements (e.g., tropes, kinks, themes, moods)'
+                    description: 'Element tags (tropes, themes, moods)'
                 },
                 notes: {
                     type: 'string',
-                    description: 'Quick scene notes'
+                    description: 'Quick notes'
                 },
                 scene_outline: {
                     type: 'string',
-                    description: 'Detailed scene planning and structure'
+                    description: 'Scene planning & structure'
                 },
                 scene_content: {
                     type: 'string',
-                    description: 'The actual written content of the scene'
+                    description: 'Written content'
                 },
                 scene_revisions: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Array of previous versions for tracking revisions'
+                    description: 'Previous versions'
                 }
             },
             required: ['scene_id']
@@ -194,18 +194,18 @@ export const sceneWritingSchemas = {
 
     get_scene: {
         name: 'get_scene',
-        description: 'Get detailed information about a specific scene',
+        description: 'Get scene details',
         inputSchema: {
             type: 'object',
             properties: {
                 scene_id: {
                     type: 'integer',
-                    description: 'ID of the scene'
+                    description: 'Scene ID'
                 },
                 include_characters: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include character participant details'
+                    description: 'Include character details'
                 }
             },
             required: ['scene_id']
@@ -214,26 +214,26 @@ export const sceneWritingSchemas = {
 
     list_scenes: {
         name: 'list_scenes',
-        description: 'List all scenes in a chapter',
+        description: 'List scenes',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter'
+                    description: 'Chapter ID'
                 },
                 scene_type: {
                     type: 'string',
-                    description: 'Filter by scene type (optional, use get_available_options with option_type="scene_types")'
+                    description: 'Scene type filter (use get_available_options w/ option_type="scene_types")'
                 },
                 writing_status: {
                     type: 'string',
-                    description: 'Filter by writing status (optional, use get_available_options with option_type="writing_statuses")'
+                    description: 'Status filter (use get_available_options w/ option_type="writing_statuses")'
                 },
                 include_stats: {
                     type: 'boolean',
                     default: false,
-                    description: 'Include word count statistics'
+                    description: 'Include stats'
                 }
             },
             required: ['chapter_id']
@@ -242,17 +242,17 @@ export const sceneWritingSchemas = {
 
     delete_scene: {
         name: 'delete_scene',
-        description: 'Delete a scene',
+        description: 'Delete scene',
         inputSchema: {
             type: 'object',
             properties: {
                 scene_id: {
                     type: 'integer',
-                    description: 'ID of the scene to delete'
+                    description: 'Scene ID'
                 },
                 confirm_deletion: {
                     type: 'boolean',
-                    description: 'Must be true to confirm deletion'
+                    description: 'Confirm (must be true)'
                 }
             },
             required: ['scene_id', 'confirm_deletion']
@@ -261,13 +261,13 @@ export const sceneWritingSchemas = {
 
     reorder_scenes: {
         name: 'reorder_scenes',
-        description: 'Reorder scenes within a chapter by updating scene numbers',
+        description: 'Reorder scenes',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter'
+                    description: 'Chapter ID'
                 },
                 scene_order: {
                     type: 'array',
@@ -279,7 +279,7 @@ export const sceneWritingSchemas = {
                         },
                         required: ['scene_id', 'new_scene_number']
                     },
-                    description: 'Array of scene IDs and their new scene numbers'
+                    description: 'Scene IDs w/ new numbers'
                 }
             },
             required: ['chapter_id', 'scene_order']
@@ -288,18 +288,18 @@ export const sceneWritingSchemas = {
 
     analyze_scene_flow: {
         name: 'analyze_scene_flow',
-        description: 'Analyze the flow and pacing between scenes in a chapter',
+        description: 'Analyze scene flow & pacing',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: {
                     type: 'integer',
-                    description: 'ID of the chapter to analyze'
+                    description: 'Chapter ID'
                 },
                 include_suggestions: {
                     type: 'boolean',
                     default: true,
-                    description: 'Include improvement suggestions'
+                    description: 'Include suggestions'
                 }
             },
             required: ['chapter_id']

--- a/src/mcps/character-server/schemas/character-tools-schema.js
+++ b/src/mcps/character-server/schemas/character-tools-schema.js
@@ -8,7 +8,7 @@
 export const characterToolsSchema = [
     {
         name: 'list_characters',
-        description: 'List all characters in a series with optional filtering',
+        description: 'List characters in series',
         inputSchema: {
             type: 'object',
             properties: {
@@ -16,12 +16,12 @@ export const characterToolsSchema = [
                 character_type: {
                     type: 'string',
                     enum: ['main', 'supporting', 'minor', 'antagonist'],
-                    description: 'Filter by character type (optional)'
+                    description: 'Type filter'
                 },
                 status: {
                     type: 'string',
                     enum: ['alive', 'dead', 'missing', 'unknown'],
-                    description: 'Filter by character status (optional)'
+                    description: 'Status filter'
                 }
             },
             required: ['series_id']
@@ -29,7 +29,7 @@ export const characterToolsSchema = [
     },
     {
         name: 'get_character',
-        description: 'Get detailed information about a character',
+        description: 'Get character details',
         inputSchema: {
             type: 'object',
             properties: {
@@ -40,28 +40,28 @@ export const characterToolsSchema = [
     },
     {
         name: 'create_character',
-        description: 'Create a new character in a series',
+        description: 'Create character',
         inputSchema: {
             type: 'object',
             properties: {
-                series_id: { type: 'integer', description: 'ID of the series' },
-                name: { type: 'string', description: 'Character\'s primary name' },
-                full_name: { type: 'string', description: 'Character\'s full name (optional)' },
+                series_id: { type: 'integer', description: 'Series ID' },
+                name: { type: 'string', description: 'Primary name' },
+                full_name: { type: 'string', description: 'Full name' },
                 aliases: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Alternative names/nicknames (optional)'
+                    description: 'Alt names/nicknames'
                 },
                 character_type: {
                     type: 'string',
                     enum: ['main', 'supporting', 'minor', 'antagonist'],
-                    description: 'Character importance level'
+                    description: 'Importance level'
                 },
-                first_appearance_book_id: { type: 'integer', description: 'Book where character first appears (optional)' },
+                first_appearance_book_id: { type: 'integer', description: 'First appearance book ID' },
                 status: {
                     type: 'string',
                     enum: ['alive', 'dead', 'missing', 'unknown'],
-                    description: 'Character\'s current status'
+                    description: 'Status'
                 }
             },
             required: ['series_id', 'name']
@@ -69,22 +69,22 @@ export const characterToolsSchema = [
     },
     {
         name: 'update_character',
-        description: 'Update character information',
+        description: 'Update character',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
-                name: { type: 'string', description: 'Character\'s primary name' },
-                full_name: { type: 'string', description: 'Character\'s full name' },
+                name: { type: 'string', description: 'Primary name' },
+                full_name: { type: 'string', description: 'Full name' },
                 character_type: {
                     type: 'string',
                     enum: ['main', 'supporting', 'minor', 'antagonist'],
-                    description: 'Character importance level'
+                    description: 'Importance level'
                 },
                 status: {
                     type: 'string',
                     enum: ['alive', 'dead', 'missing', 'unknown'],
-                    description: 'Character\'s current status'
+                    description: 'Status'
                 }
             },
             required: ['character_id']
@@ -98,25 +98,25 @@ export const characterToolsSchema = [
 export const characterDetailToolsSchema = [
     {
         name: 'add_character_detail',
-        description: 'Add or update a character detail (physical trait, personality, background, etc.)',
+        description: 'Add/update character detail',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 category: {
                     type: 'string',
-                    description: 'Detail category (e.g., \'physical\', \'personality\', \'background\', \'skills\')'
+                    description: 'Category (physical/personality/background/skills)'
                 },
                 attribute: {
                     type: 'string',
-                    description: 'Specific attribute (e.g., \'eye_color\', \'height\', \'temperament\')'
+                    description: 'Attribute (eye_color/height/temperament)'
                 },
-                value: { type: 'string', description: 'The detail value' },
-                source_book_id: { type: 'integer', description: 'Book where this detail was established (optional)' },
+                value: { type: 'string', description: 'Value' },
+                source_book_id: { type: 'integer', description: 'Source book ID' },
                 confidence_level: {
                     type: 'string',
                     enum: ['established', 'mentioned', 'implied'],
-                    description: 'How definitively this detail was stated'
+                    description: 'Confidence level'
                 }
             },
             required: ['character_id', 'category', 'attribute', 'value']
@@ -124,14 +124,14 @@ export const characterDetailToolsSchema = [
     },
     {
         name: 'get_character_details',
-        description: 'Get all details for a character, optionally filtered by category',
+        description: 'Get character details',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 category: {
                     type: 'string',
-                    description: 'Filter by detail category (optional)'
+                    description: 'Category filter'
                 }
             },
             required: ['character_id']
@@ -139,25 +139,25 @@ export const characterDetailToolsSchema = [
     },
     {
         name: 'update_character_detail',
-        description: 'Update an existing character detail',
+        description: 'Update character detail',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 category: {
                     type: 'string',
-                    description: 'Detail category (e.g., \'physical\', \'personality\', \'background\', \'skills\')'
+                    description: 'Category (physical/personality/background/skills)'
                 },
                 attribute: {
                     type: 'string',
-                    description: 'Specific attribute to update (e.g., \'eye_color\', \'height\', \'temperament\')'
+                    description: 'Attribute to update'
                 },
-                value: { type: 'string', description: 'The new detail value' },
-                source_book_id: { type: 'integer', description: 'Book where this detail was updated (optional)' },
+                value: { type: 'string', description: 'New value' },
+                source_book_id: { type: 'integer', description: 'Source book ID' },
                 confidence_level: {
                     type: 'string',
                     enum: ['established', 'mentioned', 'implied'],
-                    description: 'How definitively this detail was stated'
+                    description: 'Confidence level'
                 }
             },
             required: ['character_id', 'category', 'attribute', 'value']
@@ -165,18 +165,18 @@ export const characterDetailToolsSchema = [
     },
     {
         name: 'delete_character_detail',
-        description: 'Delete a specific character detail',
+        description: 'Delete character detail',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 category: {
                     type: 'string',
-                    description: 'Detail category (e.g., \'physical\', \'personality\', \'background\', \'skills\')'
+                    description: 'Category'
                 },
                 attribute: {
                     type: 'string',
-                    description: 'Specific attribute to delete (e.g., \'eye_color\', \'height\', \'temperament\')'
+                    description: 'Attribute to delete'
                 }
             },
             required: ['character_id', 'category', 'attribute']
@@ -190,28 +190,28 @@ export const characterDetailToolsSchema = [
 export const characterKnowledgeToolsSchema = [
     {
         name: 'add_character_knowledge',
-        description: 'Track what a character knows (prevents plot holes)',
+        description: 'Track character knowledge',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 knowledge_category: {
                     type: 'string',
-                    description: 'Type of knowledge (e.g., \'secret\', \'skill\', \'person\', \'location\', \'event\')'
+                    description: 'Type (secret/skill/person/location/event)'
                 },
                 knowledge_item: {
                     type: 'string',
-                    description: 'What they know (e.g., \'vampire council exists\', \'Sarah is a witch\')'
+                    description: 'What they know'
                 },
                 knowledge_level: {
                     type: 'string',
                     enum: ['knows', 'suspects', 'unaware', 'forgot'],
-                    description: 'How well they know this information'
+                    description: 'Knowledge level'
                 },
-                learned_book_id: { type: 'integer', description: 'Book where they learned this (optional)' },
+                learned_book_id: { type: 'integer', description: 'Book learned in' },
                 learned_context: {
                     type: 'string',
-                    description: 'How/when they learned this information (optional)'
+                    description: 'How/when learned'
                 }
             },
             required: ['character_id', 'knowledge_category', 'knowledge_item']
@@ -219,30 +219,30 @@ export const characterKnowledgeToolsSchema = [
     },
     {
         name: 'add_character_knowledge_with_chapter',
-        description: 'Add character knowledge with specific chapter reference',
+        description: 'Add knowledge w/ chapter ref',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 knowledge_category: {
                     type: 'string',
-                    description: 'Type of knowledge (e.g., \'secret\', \'skill\', \'person\', \'location\', \'event\')'
+                    description: 'Type (secret/skill/person/location/event)'
                 },
                 knowledge_item: {
                     type: 'string',
-                    description: 'What they know (e.g., \'vampire council exists\', \'Sarah is a witch\')'
+                    description: 'What they know'
                 },
                 knowledge_level: {
                     type: 'string',
                     enum: ['knows', 'suspects', 'unaware', 'forgot'],
-                    description: 'How well they know this information',
+                    description: 'Knowledge level',
                     default: 'knows'
                 },
-                learned_chapter_id: { type: 'integer', description: 'Chapter where they learned this' },
-                learned_scene: { type: 'integer', description: 'Scene number where learned (optional)' },
+                learned_chapter_id: { type: 'integer', description: 'Chapter learned in' },
+                learned_scene: { type: 'integer', description: 'Scene number' },
                 learned_context: {
                     type: 'string',
-                    description: 'How/when they learned this information'
+                    description: 'How/when learned'
                 }
             },
             required: ['character_id', 'knowledge_category', 'knowledge_item', 'learned_chapter_id']
@@ -250,18 +250,18 @@ export const characterKnowledgeToolsSchema = [
     },
     {
         name: 'check_character_knowledge',
-        description: 'Check what a character knows about a specific topic',
+        description: 'Check character knowledge',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 knowledge_item: {
                     type: 'string',
-                    description: 'What to check (can be partial match)'
+                    description: 'Item to check (partial match)'
                 },
                 knowledge_category: {
                     type: 'string',
-                    description: 'Filter by knowledge category (optional)'
+                    description: 'Category filter'
                 }
             },
             required: ['character_id']
@@ -269,19 +269,19 @@ export const characterKnowledgeToolsSchema = [
     },
     {
         name: 'get_characters_who_know',
-        description: 'Find all characters who know about a specific thing',
+        description: 'Find who knows about something',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: { type: 'integer', description: 'Series ID' },
                 knowledge_item: {
                     type: 'string',
-                    description: 'What to search for (partial match supported)'
+                    description: 'Search term (partial match)'
                 },
                 knowledge_level: {
                     type: 'string',
                     enum: ['knows', 'suspects', 'unaware', 'forgot'],
-                    description: 'Filter by knowledge level (optional)'
+                    description: 'Level filter'
                 }
             },
             required: ['series_id', 'knowledge_item']
@@ -295,70 +295,70 @@ export const characterKnowledgeToolsSchema = [
 export const characterTimelineToolsSchema = [
     {
         name: 'track_character_presence',
-        description: 'Track a character\'s presence and state in a specific chapter',
+        description: 'Track character in chapter',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
                 chapter_id: { type: 'integer', description: 'Chapter ID' },
-                scene_id: { type: 'integer', description: 'Specific scene within chapter (optional)' },
+                scene_id: { type: 'integer', description: 'Scene ID' },
                 presence_type: {
                     type: 'string',
                     enum: ['present', 'mentioned', 'flashback', 'dream', 'phone_call'],
-                    description: 'How the character appears in this chapter'
+                    description: 'Presence type'
                 },
                 importance_level: {
                     type: 'string',
                     enum: ['major', 'minor', 'cameo', 'background'],
-                    description: 'Character\'s importance in this chapter'
+                    description: 'Importance'
                 },
-                physical_state: { type: 'string', description: 'Physical condition (injured, disguised, etc.)' },
-                emotional_state: { type: 'string', description: 'Emotional state (angry, suspicious, etc.)' },
-                enters_at_scene: { type: 'integer', description: 'Scene number when they arrive' },
-                exits_at_scene: { type: 'integer', description: 'Scene number when they leave' },
+                physical_state: { type: 'string', description: 'Physical state' },
+                emotional_state: { type: 'string', description: 'Emotional state' },
+                enters_at_scene: { type: 'integer', description: 'Entry scene #' },
+                exits_at_scene: { type: 'integer', description: 'Exit scene #' },
                 learns_this_chapter: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'New information learned in this chapter'
+                    description: 'Info learned'
                 },
                 reveals_this_chapter: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Secrets revealed in this chapter'
+                    description: 'Secrets revealed'
                 },
-                character_growth: { type: 'string', description: 'How the character changes in this chapter' }
+                character_growth: { type: 'string', description: 'Character changes' }
             },
             required: ['character_id', 'chapter_id', 'presence_type']
         }
     },
     {
         name: 'get_character_timeline',
-        description: 'Get a character\'s complete timeline across chapters showing their progression',
+        description: 'Get character timeline',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
-                book_id: { type: 'integer', description: 'Specific book (optional - shows all books if not provided)' },
-                include_scenes: { type: 'boolean', description: 'Include scene-level details', default: false },
-                include_knowledge: { type: 'boolean', description: 'Include knowledge gained per chapter', default: true },
-                include_relationships: { type: 'boolean', description: 'Include relationship changes', default: false }
+                book_id: { type: 'integer', description: 'Book ID' },
+                include_scenes: { type: 'boolean', description: 'Include scenes', default: false },
+                include_knowledge: { type: 'boolean', description: 'Include knowledge', default: true },
+                include_relationships: { type: 'boolean', description: 'Include relationships', default: false }
             },
             required: ['character_id']
         }
     },
     {
         name: 'check_character_continuity',
-        description: 'Verify character consistency across chapter boundaries',
+        description: 'Check character continuity',
         inputSchema: {
             type: 'object',
             properties: {
                 character_id: { type: 'integer', description: 'Character ID' },
-                from_chapter_id: { type: 'integer', description: 'Starting chapter' },
-                to_chapter_id: { type: 'integer', description: 'Ending chapter' },
+                from_chapter_id: { type: 'integer', description: 'Start chapter' },
+                to_chapter_id: { type: 'integer', description: 'End chapter' },
                 check_type: {
                     type: 'string',
                     enum: ['physical_state', 'emotional_state', 'knowledge', 'location', 'all'],
-                    description: 'What type of continuity to check',
+                    description: 'Check type',
                     default: 'all'
                 }
             },
@@ -367,21 +367,21 @@ export const characterTimelineToolsSchema = [
     },
     {
         name: 'get_characters_in_chapter',
-        description: 'Get all characters present in a specific chapter with their roles and states',
+        description: 'Get chapter characters',
         inputSchema: {
             type: 'object',
             properties: {
                 chapter_id: { type: 'integer', description: 'Chapter ID' },
-                scene_number: { type: 'integer', description: 'Filter to specific scene within chapter (optional)' },
+                scene_number: { type: 'integer', description: 'Scene # filter' },
                 presence_type: {
                     type: 'string',
                     enum: ['present', 'mentioned', 'flashback', 'dream', 'phone_call'],
-                    description: 'Filter by presence type (optional)'
+                    description: 'Presence filter'
                 },
                 importance_level: {
                     type: 'string',
                     enum: ['major', 'minor', 'cameo', 'background'],
-                    description: 'Filter by importance level (optional)'
+                    description: 'Importance filter'
                 }
             },
             required: ['chapter_id']

--- a/src/mcps/metadata-server/schemas/lookup-tools-schema.js
+++ b/src/mcps/metadata-server/schemas/lookup-tools-schema.js
@@ -4,23 +4,23 @@
 export const lookupSystemToolsSchema = [
     {
         name: 'get_available_options',
-        description: 'Get available options from lookup tables (genres, plot thread types, story elements, etc.)',
+        description: 'Get lookup table options',
         inputSchema: {
             type: 'object',
             properties: {
                 option_type: {
                     type: 'string',
                     enum: ['genres', 'plot_thread_types', 'plot_thread_statuses', 'relationship_types', 'story_concerns', 'story_outcomes', 'story_judgments', 'scene_purposes', 'scene_types', 'writing_statuses'],
-                    description: 'Type of options to retrieve'
+                    description: 'Option type'
                 },
                 genre_filter: {
                     type: 'string',
-                    description: 'Filter by specific genre name (optional)'
+                    description: 'Genre name filter'
                 },
                 active_only: {
                     type: 'boolean',
                     default: true,
-                    description: 'Only return active/available options'
+                    description: 'Active options only'
                 }
             },
             required: ['option_type']
@@ -28,27 +28,27 @@ export const lookupSystemToolsSchema = [
     },
     {
         name: 'create_lookup_option',
-        description: 'Create a new lookup option (genre, plot thread type, status, etc.) - Admin function',
+        description: 'Create lookup option - Admin',
         inputSchema: {
             type: 'object',
             properties: {
                 option_type: {
                     type: 'string',
                     enum: ['genres', 'plot_thread_types', 'plot_thread_statuses', 'relationship_types', 'story_concerns', 'story_outcomes', 'story_judgments', 'scene_purposes', 'scene_types', 'writing_statuses'],
-                    description: 'Type of option to create'
+                    description: 'Option type'
                 },
                 name: {
                     type: 'string',
-                    description: 'Name of the new option (must be unique)'
+                    description: 'Option name (unique)'
                 },
                 description: {
                     type: 'string',
-                    description: 'Description of the option'
+                    description: 'Option description'
                 },
                 is_active: {
                     type: 'boolean',
                     default: true,
-                    description: 'Whether the option is immediately active'
+                    description: 'Active immediately'
                 }
             },
             required: ['option_type', 'name', 'description']
@@ -56,30 +56,30 @@ export const lookupSystemToolsSchema = [
     },
     {
         name: 'update_lookup_option',
-        description: 'Update an existing lookup option - Admin function',
+        description: 'Update lookup option - Admin',
         inputSchema: {
             type: 'object',
             properties: {
                 option_type: {
                     type: 'string',
                     enum: ['genres', 'plot_thread_types', 'plot_thread_statuses', 'relationship_types', 'story_concerns', 'story_outcomes', 'story_judgments', 'scene_purposes', 'scene_types', 'writing_statuses'],
-                    description: 'Type of option to update'
+                    description: 'Option type'
                 },
                 option_id: {
                     type: 'integer',
-                    description: 'ID of the option to update'
+                    description: 'Option ID'
                 },
                 name: {
                     type: 'string',
-                    description: 'Updated name (optional)'
+                    description: 'Updated name'
                 },
                 description: {
                     type: 'string',
-                    description: 'Updated description (optional)'
+                    description: 'Updated description'
                 },
                 is_active: {
                     type: 'boolean',
-                    description: 'Update active status (optional)'
+                    description: 'Active status'
                 }
             },
             required: ['option_type', 'option_id']
@@ -87,23 +87,23 @@ export const lookupSystemToolsSchema = [
     },
     {
         name: 'delete_lookup_option',
-        description: 'Soft delete a lookup option (sets is_active to false) - Admin function',
+        description: 'Delete lookup option - Admin',
         inputSchema: {
             type: 'object',
             properties: {
                 option_type: {
                     type: 'string',
                     enum: ['genres', 'plot_thread_types', 'plot_thread_statuses', 'relationship_types', 'story_concerns', 'story_outcomes', 'story_judgments', 'scene_purposes', 'scene_types', 'writing_statuses'],
-                    description: 'Type of option to delete'
+                    description: 'Option type'
                 },
                 option_id: {
                     type: 'integer',
-                    description: 'ID of the option to delete'
+                    description: 'Option ID'
                 },
                 permanent: {
                     type: 'boolean',
                     default: false,
-                    description: 'If true, permanently delete (use with caution). If false, soft delete by setting is_active=false'
+                    description: 'True=permanent delete (caution), false=soft delete'
                 }
             },
             required: ['option_type', 'option_id']
@@ -111,7 +111,7 @@ export const lookupSystemToolsSchema = [
     },
     {
         name: 'assign_book_genres',
-        description: 'Assign genres to a book using the normalized genre system',
+        description: 'Assign genres to book',
         inputSchema: {
             type: 'object',
             properties: {
@@ -122,7 +122,7 @@ export const lookupSystemToolsSchema = [
                 genre_ids: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Array of genre IDs to assign (replaces existing genres)'
+                    description: 'Genre IDs (replaces existing)'
                 }
             },
             required: ['book_id', 'genre_ids']
@@ -130,7 +130,7 @@ export const lookupSystemToolsSchema = [
     },
     {
         name: 'assign_series_genres',
-        description: 'Assign genres to a series using the normalized genre system',
+        description: 'Assign genres to series',
         inputSchema: {
             type: 'object',
             properties: {
@@ -141,7 +141,7 @@ export const lookupSystemToolsSchema = [
                 genre_ids: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Array of genre IDs to assign (replaces existing genres)'
+                    description: 'Genre IDs (replaces existing)'
                 }
             },
             required: ['series_id', 'genre_ids']

--- a/src/mcps/plot-server/schemas/plot-tools-schema.js
+++ b/src/mcps/plot-server/schemas/plot-tools-schema.js
@@ -7,75 +7,75 @@
 export const plotThreadToolsSchema = [
     {
         name: 'create_plot_thread',
-        description: 'Create a new plot thread (story arc, subplot, character arc)',
+        description: 'Create plot thread',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: { type: 'integer', description: 'Series ID' },
-                title: { type: 'string', description: 'Plot thread title' },
-                description: { type: 'string', description: 'Plot thread description' },
+                title: { type: 'string', description: 'Title' },
+                description: { type: 'string', description: 'Description' },
                 thread_type: {
                     type: 'string',
-                    description: 'Type of plot thread (use metadata-server\'s get_available_options with option_type="plot_thread_types" to see valid values)'
+                    description: 'Type (use get_available_options w/ option_type="plot_thread_types")'
                 },
-                importance_level: { 
-                    type: 'integer', 
-                    minimum: 1, 
-                    maximum: 10, 
+                importance_level: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: 10,
                     default: 5,
-                    description: 'Importance level (1-10)'
+                    description: 'Importance (1-10)'
                 },
-                complexity_level: { 
-                    type: 'integer', 
-                    minimum: 1, 
-                    maximum: 10, 
+                complexity_level: {
+                    type: 'integer',
+                    minimum: 1,
+                    maximum: 10,
                     default: 5,
-                    description: 'Complexity level (1-10)'
+                    description: 'Complexity (1-10)'
                 },
-                start_book: { type: 'integer', description: 'Starting book number' },
-                end_book: { type: 'integer', description: 'Ending book number (optional for ongoing threads)' },
-                related_characters: { 
-                    type: 'array', 
+                start_book: { type: 'integer', description: 'Start book #' },
+                end_book: { type: 'integer', description: 'End book #' },
+                related_characters: {
+                    type: 'array',
                     items: { type: 'integer' },
-                    description: 'Array of related character IDs'
+                    description: 'Related character IDs'
                 },
-                parent_thread_id: { type: 'integer', description: 'Parent thread ID for sub-threads' }
+                parent_thread_id: { type: 'integer', description: 'Parent thread ID' }
             },
             required: ['series_id', 'title', 'description', 'thread_type']
         }
     },
     {
         name: 'update_plot_thread',
-        description: 'Update plot thread information and status',
+        description: 'Update plot thread',
         inputSchema: {
             type: 'object',
             properties: {
-                thread_id: { type: 'integer', description: 'Plot thread ID' },
-                title: { type: 'string', description: 'Plot thread title' },
-                description: { type: 'string', description: 'Plot thread description' },
-                current_status: { 
-                    type: 'string', 
+                thread_id: { type: 'integer', description: 'Thread ID' },
+                title: { type: 'string', description: 'Title' },
+                description: { type: 'string', description: 'Description' },
+                current_status: {
+                    type: 'string',
                     enum: ['active', 'resolved', 'on_hold', 'abandoned'],
-                    description: 'Thread status'
+                    description: 'Status'
                 },
-                end_book: { type: 'integer', description: 'Ending book number' },
+                end_book: { type: 'integer', description: 'End book #' },
                 resolution_notes: { type: 'string', description: 'Resolution details' },
-                resolution_book: { type: 'integer', description: 'Book where resolved' }
+                resolution_book: { type: 'integer', description: 'Resolution book #' }
             },
             required: ['thread_id']
         }
     },
     {
         name: 'get_plot_threads',
-        description: 'Get plot threads for a series with filtering options',
+        description: 'Get plot threads',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: { type: 'integer', description: 'Series ID' },
-                thread_type: { type: 'string', description: 'Filter by thread type' },
-                current_status: { type: 'string', description: 'Filter by status' },
-                book_number: { type: 'integer', description: 'Filter threads active in specific book' },
-                importance_min: { type: 'integer', description: 'Minimum importance level' }
+                thread_type: { type: 'string', description: 'Type filter' },
+                current_status: { type: 'string', description: 'Status filter' },
+                book_number: { type: 'integer', description: 'Book # filter' },
+                importance_min: { type: 'integer', description: 'Min importance' }
             },
             required: ['series_id']
         }
@@ -107,13 +107,13 @@ export const plotThreadToolsSchema = [
     // },
     {
         name: 'resolve_plot_thread',
-        description: 'Mark a plot thread as resolved with details',
+        description: 'Resolve plot thread',
         inputSchema: {
             type: 'object',
             properties: {
-                thread_id: { type: 'integer', description: 'Plot thread ID' },
-                resolution_book: { type: 'integer', description: 'Book where resolved' },
-                resolution_notes: { type: 'string', description: 'How the thread was resolved' }
+                thread_id: { type: 'integer', description: 'Thread ID' },
+                resolution_book: { type: 'integer', description: 'Resolution book #' },
+                resolution_notes: { type: 'string', description: 'Resolution details' }
             },
             required: ['thread_id', 'resolution_book', 'resolution_notes']
         }
@@ -132,49 +132,49 @@ export const plotThreadToolsSchema = [
 export const genreExtensionToolsSchema = [
     {
         name: 'create_information_reveal',
-        description: 'Track any information reveal across all genres (evidence, secrets, backstory, world rules)',
+        description: 'Track info reveal',
         inputSchema: {
             type: 'object',
             properties: {
                 plot_thread_id: {
                     type: 'integer',
-                    description: 'Associated plot thread ID'
+                    description: 'Plot thread ID'
                 },
                 reveal_type: {
                     type: 'string',
                     enum: ['evidence', 'secret', 'backstory', 'world_rule', 'relationship', 'skill'],
-                    description: 'Type of information being revealed'
+                    description: 'Reveal type'
                 },
                 information_content: {
                     type: 'string',
-                    description: 'What information is revealed'
+                    description: 'Info content'
                 },
                 reveal_method: {
                     type: 'string',
-                    description: 'How the information is revealed (discovered, confessed, witnessed, deduced)'
+                    description: 'Reveal method (discovered/confessed/witnessed/deduced)'
                 },
                 significance_level: {
                     type: 'string',
                     enum: ['minor', 'major', 'climactic', 'world_changing'],
-                    description: 'Impact level of this reveal'
+                    description: 'Impact level'
                 },
                 affects_characters: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Character IDs who learn this information'
+                    description: 'Character IDs who learn this'
                 },
                 revealed_in_chapter: {
                     type: 'integer',
-                    description: 'Chapter where revealed (optional)'
+                    description: 'Reveal chapter ID'
                 },
                 consequences: {
                     type: 'string',
-                    description: 'What happens as a result of this reveal (optional)'
+                    description: 'Consequences'
                 },
                 foreshadowing_chapters: {
                     type: 'array',
                     items: { type: 'integer' },
-                    description: 'Chapters where this was hinted at (optional)'
+                    description: 'Foreshadowing chapter IDs'
                 }
             },
             required: ['plot_thread_id', 'reveal_type', 'information_content', 'reveal_method', 'significance_level']
@@ -182,7 +182,7 @@ export const genreExtensionToolsSchema = [
     },
     {
         name: 'define_world_system',
-        description: 'Define any systematic supernatural/advanced element with rules and limitations',
+        description: 'Define world system w/ rules',
         inputSchema: {
             type: 'object',
             properties: {
@@ -192,30 +192,30 @@ export const genreExtensionToolsSchema = [
                 },
                 system_name: {
                     type: 'string',
-                    description: 'Name of the system'
+                    description: 'System name'
                 },
                 system_type: {
                     type: 'string',
                     enum: ['magic', 'psionics', 'technology', 'divine', 'supernatural', 'mutation', 'alchemy'],
-                    description: 'Type of system'
+                    description: 'System type'
                 },
                 power_source: {
                     type: 'string',
-                    description: 'What powers this system'
+                    description: 'Power source'
                 },
                 access_method: {
                     type: 'string',
-                    description: 'How beings access/use this system'
+                    description: 'Access method'
                 },
                 limitations: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Constraints, costs, and limitations'
+                    description: 'Constraints & limitations'
                 },
                 system_rules: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Governing rules and principles'
+                    description: 'Rules & principles'
                 },
                 power_scaling: {
                     type: 'object',
@@ -224,7 +224,7 @@ export const genreExtensionToolsSchema = [
                         highest_level: { type: 'string' },
                         progression_method: { type: 'string' }
                     },
-                    description: 'How power levels work'
+                    description: 'Power levels'
                 }
             },
             required: ['series_id', 'system_name', 'system_type', 'power_source', 'access_method']
@@ -232,35 +232,35 @@ export const genreExtensionToolsSchema = [
     },
     {
         name: 'add_reveal_evidence',
-        description: 'Add specific evidence to an information reveal (universal evidence tracking)',
+        description: 'Add evidence to reveal',
         inputSchema: {
             type: 'object',
             properties: {
                 reveal_id: {
                     type: 'integer',
-                    description: 'Information reveal ID'
+                    description: 'Reveal ID'
                 },
                 evidence_type: {
                     type: 'string',
                     enum: ['physical', 'witness', 'circumstantial', 'digital', 'forensic'],
-                    description: 'Type of evidence'
+                    description: 'Evidence type'
                 },
                 evidence_description: {
                     type: 'string',
-                    description: 'Description of the evidence'
+                    description: 'Description'
                 },
                 discovered_by: {
                     type: 'integer',
-                    description: 'Character ID who discovered this (optional)'
+                    description: 'Discoverer character ID'
                 },
                 discovery_chapter: {
                     type: 'integer',
-                    description: 'Chapter where discovered (optional)'
+                    description: 'Discovery chapter ID'
                 },
                 significance: {
                     type: 'string',
                     enum: ['critical', 'important', 'supporting', 'red_herring'],
-                    description: 'Significance of this evidence'
+                    description: 'Significance'
                 }
             },
             required: ['reveal_id', 'evidence_type', 'evidence_description']
@@ -268,7 +268,7 @@ export const genreExtensionToolsSchema = [
     },
     {
         name: 'track_system_progression',
-        description: 'Track character progression within a world system',
+        description: 'Track character system progression',
         inputSchema: {
             type: 'object',
             properties: {
@@ -278,29 +278,29 @@ export const genreExtensionToolsSchema = [
                 },
                 system_id: {
                     type: 'integer',
-                    description: 'World system ID'
+                    description: 'System ID'
                 },
                 book_id: {
                     type: 'integer',
-                    description: 'Book where progression occurs'
+                    description: 'Book ID'
                 },
                 chapter_id: {
                     type: 'integer',
-                    description: 'Chapter where progression occurs (optional)'
+                    description: 'Chapter ID'
                 },
                 current_power_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Current power level'
+                    description: 'Power level'
                 },
                 progression_method: {
                     type: 'string',
-                    description: 'How they gained this power'
+                    description: 'Progression method'
                 },
                 cost_or_sacrifice: {
                     type: 'string',
-                    description: 'What they sacrificed to gain this power (optional)'
+                    description: 'Cost/sacrifice'
                 }
             },
             required: ['character_id', 'system_id', 'book_id', 'current_power_level']

--- a/src/mcps/relationship-server/handlers/relationship-handlers.js
+++ b/src/mcps/relationship-server/handlers/relationship-handlers.js
@@ -10,17 +10,17 @@ export class RelationshipHandlers {
         return [
             {
                 name: 'create_relationship_arc',
-                description: 'Track any relationship development across all genres and relationship types',
+                description: 'Track relationship development',
                 inputSchema: {
                     type: 'object',
                     properties: {
                         plot_thread_id: {
                             type: 'integer',
-                            description: 'Associated plot thread ID'
+                            description: 'Plot thread ID'
                         },
                         arc_name: {
                             type: 'string',
-                            description: 'Name for this relationship arc'
+                            description: 'Arc name'
                         },
                         participants: {
                             type: 'array',
@@ -36,27 +36,27 @@ export class RelationshipHandlers {
                                 },
                                 required: ['character_id', 'role_in_relationship']
                             },
-                            description: 'Characters involved (2 or more, flexible roles)'
+                            description: 'Characters (2+, flexible roles)'
                         },
                         relationship_type: {
                             type: 'string',
                             enum: ['romantic', 'family', 'friendship', 'professional', 'antagonistic', 'mentor', 'alliance'],
-                            description: 'Type of relationship'
+                            description: 'Relationship type'
                         },
                         current_dynamic: {
                             type: 'string',
-                            description: 'Current relationship dynamic/stage'
+                            description: 'Current dynamic/stage'
                         },
                         development_factors: {
                             type: 'array',
                             items: { type: 'string' },
-                            description: 'What drives development in this relationship'
+                            description: 'Development drivers'
                         },
                         complexity_level: {
                             type: 'integer',
                             minimum: 1,
                             maximum: 10,
-                            description: 'Relationship complexity (1=simple, 10=very complex)'
+                            description: 'Complexity (1-10)'
                         }
                     },
                     required: ['plot_thread_id', 'arc_name', 'participants', 'relationship_type']
@@ -64,17 +64,17 @@ export class RelationshipHandlers {
             },
             {
                 name: 'update_relationship_arc',
-                description: 'Update an existing relationship arc',
+                description: 'Update relationship arc',
                 inputSchema: {
                     type: 'object',
                     properties: {
                         arc_id: {
                             type: 'integer',
-                            description: 'ID of the relationship arc to update'
+                            description: 'Arc ID'
                         },
                         arc_name: {
                             type: 'string',
-                            description: 'Name for this relationship arc'
+                            description: 'Arc name'
                         },
                         participants: {
                             type: 'array',
@@ -90,27 +90,27 @@ export class RelationshipHandlers {
                                 },
                                 required: ['character_id', 'role_in_relationship']
                             },
-                            description: 'Characters involved (2 or more, flexible roles)'
+                            description: 'Characters (2+, flexible roles)'
                         },
                         relationship_type: {
                             type: 'string',
                             enum: ['romantic', 'family', 'friendship', 'professional', 'antagonistic', 'mentor', 'alliance'],
-                            description: 'Type of relationship'
+                            description: 'Relationship type'
                         },
                         current_dynamic: {
                             type: 'string',
-                            description: 'Current relationship dynamic/stage'
+                            description: 'Current dynamic/stage'
                         },
                         development_factors: {
                             type: 'array',
                             items: { type: 'string' },
-                            description: 'What drives development in this relationship'
+                            description: 'Development drivers'
                         },
                         complexity_level: {
                             type: 'integer',
                             minimum: 1,
                             maximum: 10,
-                            description: 'Relationship complexity (1=simple, 10=very complex)'
+                            description: 'Complexity (1-10)'
                         }
                     },
                     required: ['arc_id']
@@ -118,40 +118,40 @@ export class RelationshipHandlers {
             },
             {
                 name: 'track_relationship_dynamics',
-                description: 'Track how relationship dynamics change over time',
+                description: 'Track relationship dynamics changes',
                 inputSchema: {
                     type: 'object',
                     properties: {
                         arc_id: {
                             type: 'integer',
-                            description: 'Relationship arc ID'
+                            description: 'Arc ID'
                         },
                         chapter_id: {
                             type: 'integer',
-                            description: 'Chapter where change occurs (optional)'
+                            description: 'Chapter ID'
                         },
                         scene_id: {
                             type: 'integer',
-                            description: 'Specific scene where change occurs (optional)'
+                            description: 'Scene ID'
                         },
                         dynamic_change: {
                             type: 'string',
-                            description: 'Description of how dynamic changed'
+                            description: 'How dynamic changed'
                         },
                         tension_change: {
                             type: 'integer',
                             minimum: -10,
                             maximum: 10,
-                            description: 'Change in tension level (-10 to +10)'
+                            description: 'Tension change (-10 to +10)'
                         },
                         change_type: {
                             type: 'string',
                             enum: ['emotional', 'power', 'trust', 'commitment', 'conflict'],
-                            description: 'Type of dynamic change'
+                            description: 'Change type'
                         },
                         trigger_event: {
                             type: 'string',
-                            description: 'What triggered this change'
+                            description: 'Change trigger'
                         }
                     },
                     required: ['arc_id', 'dynamic_change', 'change_type']
@@ -159,13 +159,13 @@ export class RelationshipHandlers {
             },
             {
                 name: 'get_relationship_arc',
-                description: 'Get details about a specific relationship arc',
+                description: 'Get relationship arc details',
                 inputSchema: {
                     type: 'object',
                     properties: {
                         arc_id: {
                             type: 'integer',
-                            description: 'Relationship arc ID'
+                            description: 'Arc ID'
                         }
                     },
                     required: ['arc_id']
@@ -173,31 +173,31 @@ export class RelationshipHandlers {
             },
             {
                 name: 'list_relationship_arcs',
-                description: 'List all relationship arcs, optionally filtered by plot thread or relationship type',
+                description: 'List relationship arcs',
                 inputSchema: {
                     type: 'object',
                     properties: {
                         plot_thread_id: {
                             type: 'integer',
-                            description: 'Filter by plot thread ID (optional)'
+                            description: 'Plot thread filter'
                         },
                         relationship_type: {
                             type: 'string',
                             enum: ['romantic', 'family', 'friendship', 'professional', 'antagonistic', 'mentor', 'alliance'],
-                            description: 'Filter by relationship type (optional)'
+                            description: 'Type filter'
                         }
                     }
                 }
             },
             {
                 name: 'get_relationship_timeline',
-                description: 'Get the complete timeline of dynamics changes for a relationship arc',
+                description: 'Get relationship dynamics timeline',
                 inputSchema: {
                     type: 'object',
                     properties: {
                         arc_id: {
                             type: 'integer',
-                            description: 'Relationship arc ID'
+                            description: 'Arc ID'
                         }
                     },
                     required: ['arc_id']

--- a/src/mcps/series-server/schemas/series-tools-schema.js
+++ b/src/mcps/series-server/schemas/series-tools-schema.js
@@ -4,7 +4,7 @@
 export const seriesToolsSchema = [
     {
         name: 'list_series',
-        description: 'List all book series in the database',
+        description: 'List all series',
         inputSchema: {
             type: 'object',
             properties: {},
@@ -13,43 +13,43 @@ export const seriesToolsSchema = [
     },
     {
         name: 'create_series',
-        description: 'Create a new book series',
+        description: 'Create series',
         inputSchema: {
             type: 'object',
             properties: {
-                title: { type: 'string', description: 'Series title' },
-                author_id: { type: 'integer', description: 'ID of the series author' },
-                description: { type: 'string', description: 'Series description' },
-                genre_ids: { type: 'array', items: { type: 'integer' }, description: 'Array of genre IDs for this series' },
-                start_year: { type: 'integer', description: 'Year the series began' },
-                status: { type: 'string', enum: ['ongoing', 'completed', 'hiatus'], description: 'Series status' }
+                title: { type: 'string', description: 'Title' },
+                author_id: { type: 'integer', description: 'Author ID' },
+                description: { type: 'string', description: 'Description' },
+                genre_ids: { type: 'array', items: { type: 'integer' }, description: 'Genre IDs' },
+                start_year: { type: 'integer', description: 'Start year' },
+                status: { type: 'string', enum: ['ongoing', 'completed', 'hiatus'], description: 'Status' }
             },
             required: ['title', 'author_id']
         }
     },
     {
         name: 'get_series',
-        description: 'Get detailed information about a specific series',
+        description: 'Get series details',
         inputSchema: {
             type: 'object',
             properties: {
-                series_id: { type: 'integer', description: 'The ID of the series' }
+                series_id: { type: 'integer', description: 'Series ID' }
             },
             required: ['series_id']
         }
     },
     {
         name: 'update_series',
-        description: 'Update an existing series',
+        description: 'Update series',
         inputSchema: {
             type: 'object',
             properties: {
-                series_id: { type: 'integer', description: 'The ID of the series to update' },
-                title: { type: 'string', description: 'Series title' },
-                description: { type: 'string', description: 'Series description' },
-                genre_ids: { type: 'array', items: { type: 'integer' }, description: 'Array of genre IDs for this series (replaces all existing genres)' },
-                start_year: { type: 'integer', description: 'Year the series began' },
-                status: { type: 'string', enum: ['ongoing', 'completed', 'hiatus'], description: 'Series status' }
+                series_id: { type: 'integer', description: 'Series ID' },
+                title: { type: 'string', description: 'Title' },
+                description: { type: 'string', description: 'Description' },
+                genre_ids: { type: 'array', items: { type: 'integer' }, description: 'Genre IDs (replaces all)' },
+                start_year: { type: 'integer', description: 'Start year' },
+                status: { type: 'string', enum: ['ongoing', 'completed', 'hiatus'], description: 'Status' }
             },
             required: ['series_id']
         }

--- a/src/mcps/story-analysis-server/schemas/story-analysis-tools-schema.js
+++ b/src/mcps/story-analysis-server/schemas/story-analysis-tools-schema.js
@@ -8,37 +8,37 @@
 export const storyAnalysisToolsSchema = [
     {
         name: 'analyze_story_dynamics',
-        description: 'Analyze story dynamics using narrative elements',
+        description: 'Analyze story dynamics',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: { type: 'integer', description: 'Book ID' },
                 story_concern: {
                     type: 'string',
-                    description: 'What the overall story is about (use metadata-server\'s get_available_options with option_type="story_concerns" to see valid values)'
+                    description: 'Overall story focus (use metadata-server get_available_options w/ option_type="story_concerns")'
                 },
-                main_character_problem: { type: 'string', description: 'Personal issues driving the protagonist' },
-                influence_character_impact: { type: 'string', description: 'How other characters challenge the MC' },
+                main_character_problem: { type: 'string', description: 'Protagonist issues' },
+                influence_character_impact: { type: 'string', description: 'How others challenge MC' },
                 story_outcome: {
                     type: 'string',
-                    description: 'Whether the story goal is achieved (use metadata-server\'s get_available_options with option_type="story_outcomes" to see valid values)'
+                    description: 'Goal achieved? (use metadata-server get_available_options w/ option_type="story_outcomes")'
                 },
                 story_judgment: {
                     type: 'string',
-                    description: 'Whether the outcome feels satisfying (use metadata-server\'s get_available_options with option_type="story_judgments" to see valid values)'
+                    description: 'Outcome satisfaction (use metadata-server get_available_options w/ option_type="story_judgments")'
                 },
                 thematic_elements: {
                     type: 'object',
-                    description: 'Values and themes in conflict'
+                    description: 'Conflicting themes/values'
                 },
-                analysis_notes: { type: 'string', description: 'Additional analysis notes' }
+                analysis_notes: { type: 'string', description: 'Additional notes' }
             },
             required: ['book_id']
         }
     },
     {
         name: 'track_character_throughlines',
-        description: 'Track character development throughlines',
+        description: 'Track character throughlines',
         inputSchema: {
             type: 'object',
             properties: {
@@ -47,30 +47,30 @@ export const storyAnalysisToolsSchema = [
                 throughline_type: {
                     type: 'string',
                     enum: ['main_character', 'influence_character', 'relationship', 'objective_story'],
-                    description: 'Type of character throughline'
+                    description: 'Throughline type'
                 },
-                character_problem: { type: 'string', description: 'Character\'s core problem' },
-                character_solution: { type: 'string', description: 'How character addresses the problem' },
-                character_arc: { type: 'string', description: 'Character development arc' }
+                character_problem: { type: 'string', description: 'Core problem' },
+                character_solution: { type: 'string', description: 'Problem approach' },
+                character_arc: { type: 'string', description: 'Development arc' }
             },
             required: ['book_id', 'character_id', 'throughline_type']
         }
     },
     {
         name: 'identify_story_appreciations',
-        description: 'Identify and track story appreciations that emerge organically',
+        description: 'Track story appreciations',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: { type: 'integer', description: 'Book ID' },
-                appreciation_type: { type: 'string', description: 'Type of story appreciation' },
-                appreciation_value: { type: 'string', description: 'The appreciation value' },
-                supporting_evidence: { type: 'string', description: 'Evidence from the story' },
+                appreciation_type: { type: 'string', description: 'Appreciation type' },
+                appreciation_value: { type: 'string', description: 'Appreciation value' },
+                supporting_evidence: { type: 'string', description: 'Story evidence' },
                 confidence_level: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'Confidence in this appreciation (1-10)'
+                    description: 'Confidence (1-10)'
                 }
             },
             required: ['book_id', 'appreciation_type', 'appreciation_value']
@@ -78,22 +78,22 @@ export const storyAnalysisToolsSchema = [
     },
     {
         name: 'map_problem_solutions',
-        description: 'Map problem/solution dynamics in the story',
+        description: 'Map problem/solution dynamics',
         inputSchema: {
             type: 'object',
             properties: {
                 book_id: { type: 'integer', description: 'Book ID' },
-                problem: { type: 'string', description: 'The problem being addressed' },
-                solution: { type: 'string', description: 'The solution being attempted' },
+                problem: { type: 'string', description: 'Problem addressed' },
+                solution: { type: 'string', description: 'Solution attempted' },
                 problem_level: {
                     type: 'string',
                     enum: ['overall_story', 'main_character', 'influence_character', 'relationship'],
-                    description: 'Level where the problem exists'
+                    description: 'Problem level'
                 },
                 effectiveness: {
                     type: 'string',
                     enum: ['solves', 'complicates', 'redirects', 'unknown'],
-                    description: 'How effective the solution is'
+                    description: 'Solution effectiveness'
                 }
             },
             required: ['book_id', 'problem', 'solution', 'problem_level']

--- a/src/mcps/timeline-server/schemas/timeline-chapter-mapping-schema.js
+++ b/src/mcps/timeline-server/schemas/timeline-chapter-mapping-schema.js
@@ -4,45 +4,45 @@
 export const eventChapterMappingSchemas = [
     {
         name: 'map_event_to_chapter',
-        description: 'Connect a timeline event to its presentation in a chapter',
+        description: 'Connect timeline event to chapter presentation',
         inputSchema: {
             type: 'object',
             required: ['event_id', 'chapter_id'],
             properties: {
-                event_id: { type: 'integer', description: 'Timeline event ID' },
-                chapter_id: { type: 'integer', description: 'Chapter where event appears' },
-                scene_number: { type: 'integer', description: 'Specific scene within chapter (optional)' },
+                event_id: { type: 'integer', description: 'Event ID' },
+                chapter_id: { type: 'integer', description: 'Chapter ID' },
+                scene_number: { type: 'integer', description: 'Scene # in chapter' },
                 presentation_type: {
                     type: 'string',
                     enum: ['direct_scene', 'flashback', 'memory', 'reference', 'foreshadowing', 'dream', 'retelling'],
-                    description: 'How the event is presented in the narrative'
+                    description: 'How event is presented'
                 },
-                pov_character_id: { type: 'integer', description: 'Character whose POV shows this event' },
-                event_aspect: { type: 'string', description: 'Which part or perspective of the event is shown' },
+                pov_character_id: { type: 'integer', description: 'POV character ID' },
+                event_aspect: { type: 'string', description: 'Part/perspective shown' },
                 completeness: {
                     type: 'string',
                     enum: ['full', 'partial', 'glimpse'],
-                    description: 'How completely the event is shown',
+                    description: 'Completeness level',
                     default: 'full'
                 },
-                narrative_function: { type: 'string', description: 'Purpose of showing this event here' }
+                narrative_function: { type: 'string', description: 'Purpose in narrative' }
             }
         }
     },
     {
         name: 'get_event_mappings',
-        description: 'Get chapters where a timeline event appears',
+        description: 'Get chapters where event appears',
         inputSchema: {
             type: 'object',
             required: ['event_id'],
             properties: {
-                event_id: { type: 'integer', description: 'Timeline event ID' }
+                event_id: { type: 'integer', description: 'Event ID' }
             }
         }
     },
     {
         name: 'get_chapter_events',
-        description: 'Get timeline events that appear in a chapter',
+        description: 'Get events in chapter',
         inputSchema: {
             type: 'object',
             required: ['chapter_id'],
@@ -50,63 +50,63 @@ export const eventChapterMappingSchemas = [
                 chapter_id: { type: 'integer', description: 'Chapter ID' },
                 presentation_type: {
                     type: 'string',
-                    description: 'Filter by presentation type (optional)'
+                    description: 'Presentation type filter'
                 },
                 pov_character_id: {
                     type: 'integer',
-                    description: 'Filter by POV character (optional)'
+                    description: 'POV character filter'
                 }
             }
         }
     },
     {
         name: 'update_event_mapping',
-        description: 'Update an existing event-chapter mapping',
+        description: 'Update event-chapter mapping',
         inputSchema: {
             type: 'object',
             required: ['mapping_id'],
             properties: {
-                mapping_id: { type: 'integer', description: 'ID of the mapping to update' },
-                scene_number: { type: 'integer', description: 'Specific scene within chapter' },
+                mapping_id: { type: 'integer', description: 'Mapping ID' },
+                scene_number: { type: 'integer', description: 'Scene # in chapter' },
                 presentation_type: {
                     type: 'string',
                     enum: ['direct_scene', 'flashback', 'memory', 'reference', 'foreshadowing', 'dream', 'retelling'],
-                    description: 'How the event is presented'
+                    description: 'How event is presented'
                 },
-                pov_character_id: { type: 'integer', description: 'Character POV for this presentation' },
-                event_aspect: { type: 'string', description: 'Which part of the event is shown' },
+                pov_character_id: { type: 'integer', description: 'POV character ID' },
+                event_aspect: { type: 'string', description: 'Part shown' },
                 completeness: {
                     type: 'string',
                     enum: ['full', 'partial', 'glimpse'],
-                    description: 'How completely the event is shown'
+                    description: 'Completeness level'
                 },
-                narrative_function: { type: 'string', description: 'Purpose of showing this event here' }
+                narrative_function: { type: 'string', description: 'Purpose in narrative' }
             }
         }
     },
     {
         name: 'delete_event_mapping',
-        description: 'Remove a mapping between an event and a chapter',
+        description: 'Delete event-chapter mapping',
         inputSchema: {
             type: 'object',
             required: ['mapping_id'],
             properties: {
-                mapping_id: { type: 'integer', description: 'ID of the mapping to delete' }
+                mapping_id: { type: 'integer', description: 'Mapping ID' }
             }
         }
     },
     {
         name: 'analyze_narrative_structure',
-        description: 'Analyze the relationship between chronological events and narrative presentation',
+        description: 'Analyze chronological events vs narrative presentation',
         inputSchema: {
             type: 'object',
             required: ['book_id'],
             properties: {
-                book_id: { type: 'integer', description: 'Book to analyze' },
+                book_id: { type: 'integer', description: 'Book ID' },
                 analysis_type: {
                     type: 'string',
                     enum: ['linearity', 'pov_distribution', 'event_coverage', 'all'],
-                    description: 'Type of analysis to perform',
+                    description: 'Analysis type',
                     default: 'all'
                 }
             }

--- a/src/mcps/trope-server/schemas/trope-tools-schema.js
+++ b/src/mcps/trope-server/schemas/trope-tools-schema.js
@@ -7,47 +7,47 @@
 export const tropeToolsSchema = [
     {
         name: 'create_trope',
-        description: 'Create a new trope definition with its scene types',
+        description: 'Create trope w/ scene types',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: { type: 'integer', description: 'Series ID' },
-                trope_name: { type: 'string', description: 'Name of the trope' },
+                trope_name: { type: 'string', description: 'Trope name' },
                 trope_category: {
                     type: 'string',
                     enum: ['romance_trope', 'character_trope', 'plot_trope'],
-                    description: 'Category of trope'
+                    description: 'Trope category'
                 },
-                description: { type: 'string', description: 'Description of the trope' },
+                description: { type: 'string', description: 'Trope description' },
                 common_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Common elements that appear in this trope'
+                    description: 'Common elements'
                 },
-                typical_trajectory: { type: 'string', description: 'Typical story trajectory for this trope' },
+                typical_trajectory: { type: 'string', description: 'Typical story trajectory' },
                 scene_types: {
                     type: 'array',
                     items: {
                         type: 'object',
                         properties: {
-                            scene_function: { type: 'string', description: 'Function of this scene (opening, revelation, obstacle, climax)' },
-                            scene_description: { type: 'string', description: 'Description of what happens in this scene' },
+                            scene_function: { type: 'string', description: 'Scene function (opening, revelation, obstacle, climax)' },
+                            scene_description: { type: 'string', description: 'What happens in scene' },
                             typical_placement: {
                                 type: 'string',
                                 enum: ['early', 'middle', 'climax', 'resolution'],
-                                description: 'When this scene typically occurs'
+                                description: 'When scene occurs'
                             },
-                            required: { type: 'boolean', description: 'Whether this scene is required for the trope' },
-                            narrative_purpose: { type: 'string', description: 'Purpose of this scene in the narrative' },
+                            required: { type: 'boolean', description: 'Required for trope' },
+                            narrative_purpose: { type: 'string', description: 'Purpose in narrative' },
                             emotional_beats: {
                                 type: 'array',
                                 items: { type: 'string' },
-                                description: 'Emotional beats this scene should hit'
+                                description: 'Emotional beats'
                             }
                         },
                         required: ['scene_function', 'scene_description']
                     },
-                    description: 'Scene types that make up this trope'
+                    description: 'Scene types in trope'
                 }
             },
             required: ['series_id', 'trope_name', 'trope_category', 'description']
@@ -55,18 +55,18 @@ export const tropeToolsSchema = [
     },
     {
         name: 'create_trope_instance',
-        description: 'Create an instance of a trope in a specific book',
+        description: 'Create trope instance in book',
         inputSchema: {
             type: 'object',
             properties: {
                 trope_id: { type: 'integer', description: 'Trope ID' },
-                book_id: { type: 'integer', description: 'Book ID where trope is implemented' },
-                instance_notes: { type: 'string', description: 'Notes about this specific implementation' },
-                subversion_notes: { type: 'string', description: 'How this instance subverts or varies the trope' },
+                book_id: { type: 'integer', description: 'Book ID' },
+                instance_notes: { type: 'string', description: 'Implementation notes' },
+                subversion_notes: { type: 'string', description: 'How this varies/subverts trope' },
                 completion_status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'complete', 'subverted'],
-                    description: 'Current status of trope implementation'
+                    description: 'Implementation status'
                 }
             },
             required: ['trope_id', 'book_id']
@@ -74,50 +74,50 @@ export const tropeToolsSchema = [
     },
     {
         name: 'get_trope',
-        description: 'Get detailed information about a specific trope',
+        description: 'Get trope details',
         inputSchema: {
             type: 'object',
             properties: {
-                trope_id: { type: 'integer', description: 'ID of the trope to retrieve' },
-                include_scene_types: { type: 'boolean', description: 'Whether to include scene type details', default: true }
+                trope_id: { type: 'integer', description: 'Trope ID' },
+                include_scene_types: { type: 'boolean', description: 'Include scene types', default: true }
             },
             required: ['trope_id']
         }
     },
     {
         name: 'list_tropes',
-        description: 'List all tropes, optionally filtered by series or category',
+        description: 'List tropes',
         inputSchema: {
             type: 'object',
             properties: {
-                series_id: { type: 'integer', description: 'Filter by series ID (optional)' },
-                trope_category: { type: 'string', description: 'Filter by trope category (optional)' }
+                series_id: { type: 'integer', description: 'Series filter' },
+                trope_category: { type: 'string', description: 'Category filter' }
             }
         }
     },
     {
         name: 'get_trope_instance',
-        description: 'Get details about a specific trope instance',
+        description: 'Get trope instance details',
         inputSchema: {
             type: 'object',
             properties: {
-                instance_id: { type: 'integer', description: 'ID of the trope instance' },
-                include_scenes: { type: 'boolean', description: 'Whether to include implemented scenes', default: true }
+                instance_id: { type: 'integer', description: 'Instance ID' },
+                include_scenes: { type: 'boolean', description: 'Include scenes', default: true }
             },
             required: ['instance_id']
         }
     },
     {
         name: 'list_trope_instances',
-        description: 'List all trope instances in a book',
+        description: 'List trope instances in book',
         inputSchema: {
             type: 'object',
             properties: {
-                book_id: { type: 'integer', description: 'Book ID to list tropes for' },
+                book_id: { type: 'integer', description: 'Book ID' },
                 status: {
                     type: 'string',
                     enum: ['planned', 'in_progress', 'complete', 'subverted'],
-                    description: 'Filter by completion status (optional)'
+                    description: 'Status filter'
                 }
             },
             required: ['book_id']
@@ -125,56 +125,56 @@ export const tropeToolsSchema = [
     },
     {
         name: 'implement_trope_scene',
-        description: 'Implement a specific scene type for a trope instance',
+        description: 'Implement trope scene',
         inputSchema: {
             type: 'object',
             properties: {
-                trope_instance_id: { type: 'integer', description: 'Trope instance ID' },
-                scene_type_id: { type: 'integer', description: 'Scene type ID from trope definition' },
-                scene_id: { type: 'integer', description: 'Actual scene ID in chapter_scenes (optional)' },
-                chapter_id: { type: 'integer', description: 'Chapter where scene occurs' },
-                scene_number: { type: 'integer', description: 'Scene number within chapter' },
-                scene_summary: { type: 'string', description: 'Summary of what happens in this scene' },
+                trope_instance_id: { type: 'integer', description: 'Instance ID' },
+                scene_type_id: { type: 'integer', description: 'Scene type ID' },
+                scene_id: { type: 'integer', description: 'Actual scene ID in chapter_scenes' },
+                chapter_id: { type: 'integer', description: 'Chapter ID' },
+                scene_number: { type: 'integer', description: 'Scene # in chapter' },
+                scene_summary: { type: 'string', description: 'What happens in scene' },
                 effectiveness_rating: {
                     type: 'integer',
                     minimum: 1,
                     maximum: 10,
-                    description: 'How effectively this scene implements the trope (1-10)',
+                    description: 'Effectiveness (1-10)',
                     default: 7
                 },
-                variation_notes: { type: 'string', description: 'How this scene varies from the typical implementation' },
+                variation_notes: { type: 'string', description: 'Variations from typical' },
                 scene_elements: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Genre-specific elements featured (investigation techniques, magic types, intimate elements, etc.)'
+                    description: 'Genre elements featured'
                 },
-                implementation_notes: { type: 'string', description: 'Additional implementation details' }
+                implementation_notes: { type: 'string', description: 'Implementation details' }
             },
             required: ['trope_instance_id', 'scene_type_id', 'scene_summary']
         }
     },
     {
         name: 'get_trope_scenes',
-        description: 'Get all trope scene implementations for an instance or series',
+        description: 'Get trope scene implementations',
         inputSchema: {
             type: 'object',
             properties: {
-                instance_id: { type: 'integer', description: 'Get scenes for specific trope instance' },
-                series_id: { type: 'integer', description: 'Get all trope scenes in series' },
-                trope_category: { type: 'string', description: 'Filter by trope category (romance_trope, etc.)' },
+                instance_id: { type: 'integer', description: 'Instance filter' },
+                series_id: { type: 'integer', description: 'Series filter' },
+                trope_category: { type: 'string', description: 'Category filter' },
                 kinks_filter: {
                     type: 'array',
                     items: { type: 'string' },
-                    description: 'Filter by specific genre elements/kinks featured'
+                    description: 'Genre elements filter'
                 },
                 written_only: {
                     type: 'boolean',
-                    description: 'If true, only return trope scenes linked to actual chapter_scenes (scene_id IS NOT NULL)',
+                    description: 'Only scenes w/ scene_id',
                     default: false
                 },
                 unwritten_only: {
                     type: 'boolean',
-                    description: 'If true, only return planned trope scenes not yet written (scene_id IS NULL)',
+                    description: 'Only planned scenes w/o scene_id',
                     default: false
                 }
             }
@@ -182,19 +182,19 @@ export const tropeToolsSchema = [
     },
     {
         name: 'get_trope_progress',
-        description: 'Get implementation progress for all tropes in a book',
+        description: 'Get trope implementation progress',
         inputSchema: {
             type: 'object',
             properties: {
-                book_id: { type: 'integer', description: 'Book ID to check' },
-                trope_id: { type: 'integer', description: 'Filter by specific trope (optional)' }
+                book_id: { type: 'integer', description: 'Book ID' },
+                trope_id: { type: 'integer', description: 'Trope filter' }
             },
             required: ['book_id']
         }
     },
     {
         name: 'analyze_trope_patterns',
-        description: 'Analyze trope usage patterns across a series',
+        description: 'Analyze trope usage patterns',
         inputSchema: {
             type: 'object',
             properties: {
@@ -202,12 +202,12 @@ export const tropeToolsSchema = [
                 trope_category: {
                     type: 'string',
                     enum: ['romance_trope', 'character_trope', 'plot_trope'],
-                    description: 'Filter by trope category (optional)'
+                    description: 'Category filter'
                 },
                 analysis_type: {
                     type: 'string',
                     enum: ['frequency', 'subversion', 'effectiveness'],
-                    description: 'Type of analysis to perform'
+                    description: 'Analysis type'
                 }
             },
             required: ['series_id']

--- a/src/mcps/world-server/schemas/world-management-schema.js
+++ b/src/mcps/world-server/schemas/world-management-schema.js
@@ -4,21 +4,21 @@
 export const worldManagementSchemas = [
     {
         name: 'check_world_consistency',
-        description: 'Validate world logic and consistency across all world elements',
+        description: 'Validate world logic and consistency',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID to check for consistency'
+                    description: 'Series ID'
                 },
                 check_type: {
                     type: 'string',
-                    description: 'Type of consistency check: all, locations, elements, organizations, relationships'
+                    description: 'Check type: all, locations, elements, organizations, relationships'
                 },
                 severity_threshold: {
                     type: 'string',
-                    description: 'Minimum severity to report: info, warning, error'
+                    description: 'Min severity: info, warning, error'
                 }
             },
             required: ['series_id']
@@ -26,25 +26,25 @@ export const worldManagementSchemas = [
     },
     {
         name: 'generate_world_guide',
-        description: 'Create comprehensive world reference guide',
+        description: 'Generate world reference guide',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID to generate guide for'
+                    description: 'Series ID'
                 },
                 guide_type: {
                     type: 'string',
-                    description: 'Type of guide: complete, locations_only, elements_only, organizations_only, summary'
+                    description: 'Guide type: complete, locations_only, elements_only, organizations_only, summary'
                 },
                 include_usage_stats: {
                     type: 'boolean',
-                    description: 'Include story usage statistics'
+                    description: 'Include usage stats'
                 },
                 format: {
                     type: 'string',
-                    description: 'Output format: text, structured, reference_sheet'
+                    description: 'Format: text, structured, reference_sheet'
                 }
             },
             required: ['series_id']
@@ -52,17 +52,17 @@ export const worldManagementSchemas = [
     },
     {
         name: 'analyze_world_complexity',
-        description: 'Analyze the complexity and depth of world-building',
+        description: 'Analyze world-building complexity',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID to analyze'
+                    description: 'Series ID'
                 },
                 analysis_focus: {
                     type: 'string',
-                    description: 'Focus area: overall, power_structures, magic_systems, geography, relationships'
+                    description: 'Focus: overall, power_structures, magic_systems, geography, relationships'
                 }
             },
             required: ['series_id']
@@ -70,17 +70,17 @@ export const worldManagementSchemas = [
     },
     {
         name: 'find_world_gaps',
-        description: 'Identify gaps or underutilized areas in world-building',
+        description: 'Find gaps in world-building',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID to analyze for gaps'
+                    description: 'Series ID'
                 },
                 gap_type: {
                     type: 'string',
-                    description: 'Type of gaps to find: unused_locations, weak_organizations, underused_elements, missing_connections'
+                    description: 'Gap type: unused_locations, weak_organizations, underused_elements, missing_connections'
                 }
             },
             required: ['series_id']
@@ -88,17 +88,17 @@ export const worldManagementSchemas = [
     },
     {
         name: 'validate_world_relationships',
-        description: 'Check relationships and connections between world elements',
+        description: 'Validate world element relationships',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID to validate'
+                    description: 'Series ID'
                 },
                 relationship_type: {
                     type: 'string',
-                    description: 'Type to validate: all, location_hierarchies, org_alliances, element_interactions'
+                    description: 'Type: all, location_hierarchies, org_alliances, element_interactions'
                 }
             },
             required: ['series_id']
@@ -106,17 +106,17 @@ export const worldManagementSchemas = [
     },
     {
         name: 'get_world_overview',
-        description: 'Get comprehensive overview of world elements',
+        description: 'Get world elements overview',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID to get overview for'
+                    description: 'Series ID'
                 },
                 include_stats: {
                     type: 'boolean',
-                    description: 'Include usage statistics',
+                    description: 'Include stats',
                     default: true
                 }
             },
@@ -125,17 +125,17 @@ export const worldManagementSchemas = [
     },
     {
         name: 'analyze_world_usage',
-        description: 'Analyze how world elements are used in the story',
+        description: 'Analyze world element usage in story',
         inputSchema: {
             type: 'object',
             properties: {
                 series_id: {
                     type: 'integer',
-                    description: 'Series ID to analyze'
+                    description: 'Series ID'
                 },
                 element_type: {
                     type: 'string',
-                    description: 'Filter by element type: location, world_element, organization, all',
+                    description: 'Element type: location, world_element, organization, all',
                     default: 'all'
                 }
             },

--- a/src/mcps/writing-server/handlers/export-handlers.js
+++ b/src/mcps/writing-server/handlers/export-handlers.js
@@ -9,35 +9,35 @@ export class ExportHandlers {
         return [
             {
                 name: 'export_manuscript',
-                description: 'Export complete manuscript in various formats - AI team prepares automatically',
+                description: 'Export manuscript - AI prepares auto',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book to export' 
+                            description: 'Book ID'
                         },
                         export_format: {
                             type: 'string',
                             enum: ['txt', 'md', 'rtf', 'standard_manuscript'],
                             default: 'txt',
-                            description: 'Export format for manuscript'
+                            description: 'Export format'
                         },
                         include_metadata: {
                             type: 'boolean',
                             default: true,
-                            description: 'Include chapter summaries and metadata'
+                            description: 'Include metadata'
                         },
                         chapters_to_include: {
                             type: 'array',
                             items: { type: 'integer' },
-                            description: 'Specific chapters to include (optional - includes all if not provided)'
+                            description: 'Chapter IDs (all if omitted)'
                         },
                         export_purpose: {
                             type: 'string',
                             enum: ['submission', 'beta_review', 'backup', 'publication'],
                             default: 'backup',
-                            description: 'Purpose of export for formatting decisions'
+                            description: 'Export purpose'
                         }
                     },
                     required: ['book_id']
@@ -45,29 +45,29 @@ export class ExportHandlers {
             },
             {
                 name: 'word_count_tracking',
-                description: 'Track and analyze word counts across manuscript - AI team monitors automatically',
+                description: 'Track word counts - AI monitors auto',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book to analyze' 
+                            description: 'Book ID'
                         },
                         tracking_level: {
                             type: 'string',
                             enum: ['book', 'chapter', 'scene', 'detailed'],
                             default: 'chapter',
-                            description: 'Level of word count detail to track'
+                            description: 'Detail level'
                         },
                         include_history: {
                             type: 'boolean',
                             default: false,
-                            description: 'Include word count change history'
+                            description: 'Include history'
                         },
                         calculate_targets: {
                             type: 'boolean',
                             default: true,
-                            description: 'Calculate progress against targets'
+                            description: 'Calc vs targets'
                         }
                     },
                     required: ['book_id']

--- a/src/mcps/writing-server/handlers/session-handlers.js
+++ b/src/mcps/writing-server/handlers/session-handlers.js
@@ -9,49 +9,49 @@ export class SessionHandlers {
         return [
             {
                 name: 'log_writing_session',
-                description: 'Log a writing session with productivity metrics - AI team tracks automatically',
+                description: 'Log writing session w/ metrics - AI tracks auto',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book being worked on' 
+                            description: 'Book ID'
                         },
                         chapter_ids: {
                             type: 'array',
                             items: { type: 'integer' },
-                            description: 'Chapters worked on during session'
+                            description: 'Chapter IDs worked on'
                         },
-                        session_date: { 
+                        session_date: {
                             type: 'string',
-                            description: 'Date of writing session (YYYY-MM-DD)' 
+                            description: 'Date (YYYY-MM-DD)'
                         },
-                        start_time: { 
+                        start_time: {
                             type: 'string',
-                            description: 'Session start time (HH:MM)' 
+                            description: 'Start (HH:MM)'
                         },
-                        end_time: { 
+                        end_time: {
                             type: 'string',
-                            description: 'Session end time (HH:MM)' 
+                            description: 'End (HH:MM)'
                         },
-                        words_written: { 
+                        words_written: {
                             type: 'integer',
-                            description: 'New words created during session' 
+                            description: 'New words'
                         },
-                        words_edited: { 
+                        words_edited: {
                             type: 'integer',
-                            description: 'Existing words edited/revised',
-                            default: 0 
+                            description: 'Edited words',
+                            default: 0
                         },
-                        session_notes: { 
+                        session_notes: {
                             type: 'string',
-                            description: 'Optional notes about the session' 
+                            description: 'Session notes'
                         },
                         mood_rating: {
                             type: 'integer',
                             minimum: 1,
                             maximum: 10,
-                            description: 'Author mood/energy level (1-10)'
+                            description: 'Mood/energy (1-10)'
                         }
                     },
                     required: ['book_id', 'session_date', 'words_written']
@@ -59,24 +59,24 @@ export class SessionHandlers {
             },
             {
                 name: 'get_writing_progress',
-                description: 'Get writing progress analytics - AI team monitors automatically',
+                description: 'Get progress analytics - AI monitors auto',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book to analyze' 
+                            description: 'Book ID'
                         },
                         time_period: {
                             type: 'string',
                             enum: ['week', 'month', 'quarter', 'all_time'],
                             default: 'month',
-                            description: 'Time period for analysis'
+                            description: 'Time period'
                         },
                         include_analytics: {
                             type: 'boolean',
                             default: true,
-                            description: 'Include detailed productivity analytics'
+                            description: 'Include details'
                         }
                     },
                     required: ['book_id']
@@ -84,30 +84,30 @@ export class SessionHandlers {
             },
             {
                 name: 'set_writing_goals',
-                description: 'Set writing goals for AI team to track progress against',
+                description: 'Set goals for AI tracking',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book for goal setting' 
+                            description: 'Book ID'
                         },
                         goal_type: {
                             type: 'string',
                             enum: ['daily_words', 'weekly_words', 'monthly_words', 'chapter_completion', 'book_completion'],
-                            description: 'Type of writing goal'
+                            description: 'Goal type'
                         },
-                        target_value: { 
+                        target_value: {
                             type: 'integer',
-                            description: 'Target number (words, chapters, etc.)' 
+                            description: 'Target # (words, chapters, etc.)'
                         },
-                        target_date: { 
+                        target_date: {
                             type: 'string',
-                            description: 'Goal completion date (YYYY-MM-DD)' 
+                            description: 'Target date (YYYY-MM-DD)'
                         },
-                        description: { 
+                        description: {
                             type: 'string',
-                            description: 'Goal description or motivation' 
+                            description: 'Goal description'
                         }
                     },
                     required: ['book_id', 'goal_type', 'target_value', 'target_date']
@@ -115,19 +115,19 @@ export class SessionHandlers {
             },
             {
                 name: 'get_productivity_analytics',
-                description: 'Get detailed productivity analytics - AI team analyzes patterns',
+                description: 'Get productivity analytics - AI analyzes patterns',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book to analyze' 
+                            description: 'Book ID'
                         },
                         analysis_type: {
                             type: 'string',
                             enum: ['daily_patterns', 'weekly_trends', 'goal_progress', 'productivity_factors'],
                             default: 'daily_patterns',
-                            description: 'Type of analysis to perform'
+                            description: 'Analysis type'
                         },
                         date_range: {
                             type: 'object',
@@ -135,7 +135,7 @@ export class SessionHandlers {
                                 start_date: { type: 'string' },
                                 end_date: { type: 'string' }
                             },
-                            description: 'Optional date range for analysis'
+                            description: 'Date range'
                         }
                     },
                     required: ['book_id']

--- a/src/mcps/writing-server/handlers/validation-handlers.js
+++ b/src/mcps/writing-server/handlers/validation-handlers.js
@@ -9,24 +9,24 @@ export class ValidationHandlers {
         return [
             {
                 name: 'validate_chapter_structure',
-                description: 'Validate chapter structure and consistency - AI team checks automatically',
+                description: 'Validate chapter structure - AI checks auto',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book to validate' 
+                            description: 'Book ID'
                         },
                         chapter_ids: {
                             type: 'array',
                             items: { type: 'integer' },
-                            description: 'Specific chapters to validate (optional - validates all if not provided)'
+                            description: 'Chapter IDs (validates all if omitted)'
                         },
                         validation_level: {
                             type: 'string',
                             enum: ['basic', 'detailed', 'comprehensive'],
                             default: 'detailed',
-                            description: 'Depth of validation checks'
+                            description: 'Check depth'
                         }
                     },
                     required: ['book_id']
@@ -34,24 +34,24 @@ export class ValidationHandlers {
             },
             {
                 name: 'validate_beat_placement',
-                description: 'Validate story beats and pacing - AI team checks flow automatically',
+                description: 'Validate beats/pacing - AI checks flow auto',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book to analyze for beats' 
+                            description: 'Book ID'
                         },
                         beat_analysis_type: {
                             type: 'string',
                             enum: ['pacing', 'character_arcs', 'plot_threads', 'emotional_beats'],
                             default: 'pacing',
-                            description: 'Type of beat analysis to perform'
+                            description: 'Analysis type'
                         },
                         flexible_guidelines: {
                             type: 'boolean',
                             default: true,
-                            description: 'Use flexible guidelines rather than rigid rules'
+                            description: 'Flexible vs rigid rules'
                         }
                     },
                     required: ['book_id']
@@ -59,13 +59,13 @@ export class ValidationHandlers {
             },
             {
                 name: 'check_structure_violations',
-                description: 'Check for structural inconsistencies - AI team identifies issues',
+                description: 'Check structural issues - AI identifies auto',
                 inputSchema: {
                     type: 'object',
                     properties: {
-                        book_id: { 
+                        book_id: {
                             type: 'integer',
-                            description: 'Book to check' 
+                            description: 'Book ID'
                         },
                         violation_types: {
                             type: 'array',
@@ -74,13 +74,13 @@ export class ValidationHandlers {
                                 enum: ['character_continuity', 'timeline_consistency', 'pov_consistency', 'location_consistency', 'plot_holes']
                             },
                             default: ['character_continuity', 'timeline_consistency', 'pov_consistency'],
-                            description: 'Types of violations to check for'
+                            description: 'Violation types'
                         },
                         severity_threshold: {
                             type: 'string',
                             enum: ['info', 'warning', 'error'],
                             default: 'warning',
-                            description: 'Minimum severity level to report'
+                            description: 'Min severity'
                         }
                     },
                     required: ['book_id']


### PR DESCRIPTION
Optimized all MCP server schemas to significantly reduce token consumption:

- Shortened tool descriptions (e.g., "Create a new book" → "Create book")
- Shortened property descriptions (e.g., "The ID of the author" → "Author ID")
- Removed redundant words ("The", "of the", "for this", "(optional)")
- Used abbreviations (w/, #, pub, auto)
- Simplified verbose descriptions while maintaining clarity

Servers optimized (13 total):
- author-server
- series-server
- character-server (management, details, knowledge, timeline)
- book-server (all 5 schema files)
- plot-server
- timeline-server
- world-server
- writing-server (session, validation, export handlers)
- metadata-server
- trope-server
- relationship-server
- story-analysis-server

Estimated token savings: 30-40% reduction per schema
Benefits: Lower API costs, faster MCP communication, improved performance