### PR TITLE
Fix container name mismatch in distribution folder

### DIFF
--- a/distribution/QUICK-START.md
+++ b/distribution/QUICK-START.md
@@ -1,54 +1,55 @@
-# Quick Start - MCP Connector with Existing Database
+# Quick Start - MCP Writing System
 
-This distribution connects the MCP Connector to your **existing database** (`mcp-series-db-2`).
+This distribution provides a **complete standalone setup** with PostgreSQL database and MCP Connector.
 
 ## ✅ What This Does
 
-- Builds and runs **MCP Connector only** (no new PostgreSQL container)
-- Connects to your existing `mcp-series-db-2` database
-- Runs all 9 MCP servers on port 50880
-- Uses your existing data and migrations
+- Builds and runs **PostgreSQL database** (`mcp-writing-db`)
+- Builds and runs **MCP Connector** with all 9 MCP servers
+- Runs MCP Connector on port 50880
+- Automatically applies all database migrations
+- Ready for Typing Mind integration
 
 ## 🚀 Quick Start (3 Steps)
 
-### Step 1: Make sure your existing database is running
-
-```powershell
-# Check if your database container is running
-docker ps | findstr mcp-series-db-2
-
-# If not running, start it with your existing script
-.\scripts\start-database.ps1
-```
-
-### Step 2: Copy your existing .env file
+### Step 1: Generate environment configuration
 
 ```powershell
 cd distribution
 
-# Copy your current .env (which has the right credentials)
-copy ..\.env .env
+# Generate .env file with secure random credentials
+.\generate-env.ps1
 
-# Or use the example
-copy .env.example .env
-# Then edit to match your existing database password
+# This creates .env with auto-generated secure passwords
 ```
 
-### Step 3: Start the MCP Connector
+### Step 2: Start the complete stack
 
 ```powershell
 cd docker
 docker-compose --env-file ../.env up -d --build
 
 # Watch the logs
-docker-compose --env-file ../.env logs -f mcp-connector
+docker-compose --env-file ../.env logs -f
+```
+
+### Step 3: Verify it's working
+
+```powershell
+# From the distribution folder
+cd ..
+.\test-docker-stack.ps1 -Verbose
+
+# Or check manually
+docker ps
+# You should see: mcp-writing-db and mcp-connector
 ```
 
 ## 🧪 Test It
 
 ```powershell
 # From the distribution folder
-.\test-docker-stack.ps1 -Build -Verbose
+.\test-docker-stack.ps1 -Verbose
 ```
 
 ## ✅ Success Looks Like
@@ -108,21 +109,26 @@ After successful start:
 ### Container won't start?
 
 ```powershell
-# Check if existing database is running
-docker ps | findstr mcp-series-db-2
+# Check if database is running
+docker ps | findstr mcp-writing-db
 
 # Check logs
+docker logs mcp-writing-db
 docker logs mcp-connector
 
-# Common fix: Restart database first
-docker restart mcp-series-db-2
+# Restart both containers
+cd docker
+docker-compose --env-file ../.env restart
 ```
 
 ### Can't connect to database?
 
 ```powershell
 # Test database connection from MCP Connector
-docker exec mcp-connector psql -h mcp-series-db-2 -U writer -d mcp_series -c "SELECT 1;"
+docker exec mcp-connector psql -h mcp-writing-db -U writer -d mcp_writing_db -c "SELECT 1;"
+
+# Test directly from database container
+docker exec mcp-writing-db psql -U writer -d mcp_writing_db -c "SELECT 1;"
 
 # If fails, check .env has correct password
 cat ../.env | findstr POSTGRES_PASSWORD
@@ -147,19 +153,24 @@ After start:
 
 ```
 ┌─────────────────────────────────────┐
-│  Existing Database (already running)│
-│  Container: mcp-series-db-2         │
+│  PostgreSQL Database                │
+│  Container: mcp-writing-db          │
 │  Port: 5432                         │
-│  Database: mcp_series               │
+│  Database: mcp_writing_db           │
+│  User: writer                       │
 └──────────────┬──────────────────────┘
                │
                │ (connects to)
                │
 ┌──────────────▼──────────────────────┐
-│  NEW: MCP Connector                 │
+│  MCP Connector                      │
 │  Container: mcp-connector           │
 │  Port: 50880                        │
 │  9 MCP Servers inside               │
+│  - book-planning-server             │
+│  - chapter-planning-server          │
+│  - character-planning-server        │
+│  - and 6 more...                    │
 └─────────────────────────────────────┘
 ```
 
@@ -187,11 +198,12 @@ docker-compose --env-file ../.env logs -f mcp-connector
 ## 🎯 Next Steps
 
 Once working:
-1. ✅ Test with Typing Mind
+1. ✅ Test with Typing Mind (see connection info above)
 2. ✅ Verify all 9 MCP servers work
-3. ✅ Ready to build Electron app wrapper!
+3. ✅ Create some test data (books, chapters, characters)
+4. ✅ Ready to build Electron app wrapper!
 
 ---
 
-**Need the full setup with standalone PostgreSQL?**
-See `README-distribution.md` for the full 2-container stack.
+**For detailed documentation and advanced configuration:**
+See `README-distribution.md` for comprehensive setup guide.

--- a/distribution/README-distribution.md
+++ b/distribution/README-distribution.md
@@ -35,22 +35,22 @@ distribution/
 ### Step 1: Configure Environment
 
 ```powershell
-# Copy example environment file
-cp .env.example .env
+# Use the automated script to generate secure credentials
+.\generate-env.ps1
 
-# Edit .env and set secure passwords
-# REQUIRED:
-#   - POSTGRES_PASSWORD (database password)
-#   - MCP_AUTH_TOKEN (random secure token)
+# This creates .env with auto-generated secure passwords
+# - POSTGRES_PASSWORD (database password)
+# - MCP_AUTH_TOKEN (random secure token)
 ```
 
-**Generate secure token:**
+**Or generate manually:**
 ```powershell
-# PowerShell
+# PowerShell - generate secure token
 -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 32 | ForEach-Object {[char]$_})
 
-# Or use OpenSSL
-openssl rand -hex 32
+# Copy example and edit
+cp .env.example .env
+notepad .env
 ```
 
 ### Step 2: Start Docker Stack
@@ -96,16 +96,20 @@ docker ps
 ## What's Running?
 
 ### Container 1: PostgreSQL Database
+- **Container Name:** mcp-writing-db
 - **Port:** 5432
 - **Database:** mcp_writing_db
+- **User:** writer
 - **Purpose:** Stores all your writing data
-- **Migrations:** 21 SQL migrations applied automatically
+- **Migrations:** 21 SQL migrations applied automatically on first run
 
 ### Container 2: MCP Connector
+- **Container Name:** mcp-connector
 - **Port:** 50880
 - **Purpose:** Runs all MCP servers and exposes REST API
 - **Servers:** 9 MCP servers for writing (book planning, character planning, etc.)
 - **Auth:** Bearer token authentication
+- **Health Check:** http://localhost:50880/health
 
 ## Available MCP Servers
 

--- a/distribution/SETUP-COMPLETE.md
+++ b/distribution/SETUP-COMPLETE.md
@@ -28,17 +28,15 @@ distribution/
 
 ```powershell
 # Navigate to distribution folder
-cd c:\github\MCP-Tutorial-New\MCP-tutorial\distribution
+cd distribution
 
-# Create .env file
-cp .env.example .env
+# Generate .env file with secure credentials
+.\generate-env.ps1
 
-# IMPORTANT: Edit .env and set:
-#   - POSTGRES_PASSWORD (secure password)
-#   - MCP_AUTH_TOKEN (random 32+ character token)
+# This creates .env with auto-generated secure passwords
 
 # Run test script
-.\test-docker-stack.ps1 -Build -Verbose
+.\test-docker-stack.ps1 -Verbose
 ```
 
 ### 2. What Gets Tested
@@ -81,28 +79,31 @@ Auth Token: [your-token-here]
 ```
 ┌─────────────────────────────────────────┐
 │         Docker Network                  │
-│      (mcp-series-network)               │
+│         (mcp-network)                   │
 │                                         │
 │  ┌───────────────────────────────────┐ │
 │  │ PostgreSQL 15                     │ │
+│  │ Container: mcp-writing-db         │ │
 │  │ Port: 5432                        │ │
 │  │ Database: mcp_writing_db          │ │
+│  │ User: writer                      │ │
 │  │ Volume: mcp-writing-data          │ │
 │  └───────────────┬───────────────────┘ │
 │                  │                       │
 │  ┌───────────────▼───────────────────┐ │
 │  │ MCP Connector                     │ │
+│  │ Container: mcp-connector          │ │
 │  │ Port: 50880                       │ │
 │  │ 9 MCP Servers:                    │ │
-│  │ • book-planning                   │ │
-│  │ • chapter-planning                │ │
-│  │ • character-planning              │ │
-│  │ • core-continuity                 │ │
-│  │ • reporting                       │ │
-│  │ • review                          │ │
-│  │ • scene                           │ │
-│  │ • series-planning                 │ │
-│  │ • author (optional)               │ │
+│  │ • book-planning-server            │ │
+│  │ • chapter-planning-server         │ │
+│  │ • character-planning-server       │ │
+│  │ • core-continuity-server          │ │
+│  │ • reporting-server                │ │
+│  │ • review-server                   │ │
+│  │ • scene-server                    │ │
+│  │ • series-planning-server          │ │
+│  │ • author-server (optional)        │ │
 │  └───────────────────────────────────┘ │
 │                                         │
 └─────────────────────────────────────────┘

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -1,7 +1,36 @@
 services:
   # ========================================
+  # PostgreSQL Database
+  # ========================================
+  postgres:
+    image: postgres:15
+    container_name: mcp-writing-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-mcp_writing_db}
+      POSTGRES_USER: ${POSTGRES_USER:-writer}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      # Performance tuning
+      POSTGRES_SHARED_BUFFERS: ${POSTGRES_SHARED_BUFFERS:-256MB}
+      POSTGRES_EFFECTIVE_CACHE_SIZE: ${POSTGRES_EFFECTIVE_CACHE_SIZE:-1GB}
+      POSTGRES_MAINTENANCE_WORK_MEM: ${POSTGRES_MAINTENANCE_WORK_MEM:-128MB}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - mcp-writing-data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - ../../migrations:/migrations:ro
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-writer} -d ${POSTGRES_DB:-mcp_writing_db}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ========================================
   # MCP Connector (runs all MCP servers)
-  # Connects to existing database: mcp-series-db-2
   # ========================================
   mcp-connector:
     build:
@@ -10,16 +39,19 @@ services:
     image: mcp-writing-connector:latest
     container_name: mcp-connector
     restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
     environment:
       # MCP Connector authentication
       MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN}
       PORT: ${MCP_CONNECTOR_PORT:-50880}
 
-      # Database connection (uses existing container name)
-      DATABASE_URL: postgresql://${POSTGRES_USER:-writer}:${POSTGRES_PASSWORD}@${POSTGRES_CONTAINER_NAME:-mcp-series-db-2}:5432/${POSTGRES_DB:-mcp_series}
-      POSTGRES_HOST: ${POSTGRES_CONTAINER_NAME:-mcp-series-db-2}
+      # Database connection
+      DATABASE_URL: postgresql://${POSTGRES_USER:-writer}:${POSTGRES_PASSWORD}@${POSTGRES_CONTAINER_NAME:-mcp-writing-db}:5432/${POSTGRES_DB:-mcp_writing_db}
+      POSTGRES_HOST: ${POSTGRES_CONTAINER_NAME:-mcp-writing-db}
       POSTGRES_PORT: 5432
-      POSTGRES_DB: ${POSTGRES_DB:-mcp_series}
+      POSTGRES_DB: ${POSTGRES_DB:-mcp_writing_db}
       POSTGRES_USER: ${POSTGRES_USER:-writer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
 
@@ -65,7 +97,11 @@ services:
   #     timeout: 3s
   #     retries: 3
 
+volumes:
+  mcp-writing-data:
+    name: mcp-writing-data
+
 networks:
   mcp-network:
-    name: mcp-series-network
-    external: true
+    name: mcp-network
+    driver: bridge


### PR DESCRIPTION
- Add PostgreSQL service to docker-compose.yml as standalone container
- Standardize all container names to 'mcp-writing-db' (was inconsistent with 'mcp-series-db-2')
- Update database name to 'mcp_writing_db' throughout all files
- Change network from 'mcp-series-network' (external) to 'mcp-network' (bridge)
- Add Docker volume 'mcp-writing-data' for PostgreSQL persistence
- Update all documentation to reflect standalone distribution setup
- Fix generate-env.ps1, test-docker-stack.ps1 references
- Update QUICK-START.md to remove references to existing database
- Update README-distribution.md with correct container names
- Update SETUP-COMPLETE.md with correct architecture diagram

This creates a complete standalone distribution package with:
- PostgreSQL database (mcp-writing-db)
- MCP Connector with all 9 MCP servers
- Auto-migration on startup
- Ready for Typing Mind integration
- Prepared for future Electron app wrapper