### PR TITLE
fix: resolve postgres password escaping and docker entrypoint issues

### DIFF
--- a/distribution/.dockerignore
+++ b/distribution/.dockerignore
@@ -40,7 +40,11 @@ build/
 *.log
 
 # Distribution artifacts (but keep src and migrations accessible)
-distribution/docker/
+# Exclude docker directory but allow entrypoint script
+distribution/docker/*.yml
+distribution/docker/Dockerfile*
+distribution/docker/init.sql
+distribution/docker/nginx.conf
 scripts/
 
 # Typing Mind files (managed separately)

--- a/distribution/generate-env.ps1
+++ b/distribution/generate-env.ps1
@@ -33,8 +33,9 @@ function New-SecureToken {
 # Function to generate secure password
 function New-SecurePassword {
     param([int]$Length = 24)
-    # Include special characters for database password
-    $chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*"
+    # Use alphanumeric only to avoid shell/URL escaping issues
+    # Special characters like @, &, !, etc. can break DATABASE_URL and shell scripts
+    $chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
     $password = -join ((1..$Length) | ForEach-Object { $chars[(Get-Random -Maximum $chars.Length)] })
     return $password
 }


### PR DESCRIPTION
- Remove special characters from postgres password generation to prevent shell/URL escaping issues with DATABASE_URL connection strings
- Fix .dockerignore to allow docker-entrypoint.sh to be copied during build while still excluding other docker config files

Fixes:
- Special characters (@, &, !, etc.) breaking DATABASE_URL
- "exec /usr/local/bin/docker-entrypoint.sh: no such file or directory" error caused by .dockerignore excluding the entire distribution/docker/ directory