### PR TITLE
fix: resolve MCP-Connector entrypoint script execution issue

### DIFF
--- a/distribution/.gitattributes
+++ b/distribution/.gitattributes
@@ -1,0 +1,6 @@
+# Prevent Git from converting line endings on shell scripts
+*.sh text eol=lf
+
+# Ensure Docker files use LF
+Dockerfile* text eol=lf
+docker-entrypoint.sh text eol=lf

--- a/distribution/docker/Dockerfile.mcp-connector
+++ b/distribution/docker/Dockerfile.mcp-connector
@@ -23,9 +23,10 @@ RUN npm ci --only=production
 # Copy MCP server source code
 COPY src/ ./src/
 
-# Copy entrypoint script
+# Copy entrypoint script and ensure proper Unix line endings
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh && \
+    chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \


### PR DESCRIPTION
The MCP-Connector service was failing to start with error: "exec /usr/local/bin/docker-entrypoint.sh: no such file or directory"

Changes:
- Updated Dockerfile.mcp-connector to strip Windows CRLF line endings from the entrypoint script using sed before making it executable
- Added .gitattributes file to ensure shell scripts always use LF line endings, preventing future line ending issues across different platforms

This ensures the entrypoint script executes correctly regardless of the development platform (Windows/Mac/Linux).