### PR TITLE
fix: correct Claude skill file structure and front matter

### DIFF
--- a/.claude/skills/mcp-writer/SKILL.md
+++ b/.claude/skills/mcp-writer/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: mcp-writer
 description: Interact with MCP writing tool servers through code execution for efficient token usage
-tags: [mcp, writing, database, code-execution]
-version: 1.0.0
 ---
 
 # MCP Writer Skill


### PR DESCRIPTION
- Rename mcp-writer.md to SKILL.md per Claude skills requirements
- Remove non-standard front matter fields (tags, version)
- Keep only required fields (name, description) in YAML front matter

Refs: https://github.com/anthropics/skills