### PR TITLE
fix: correct mcp-db-tools skill file structure and front matter

### DIFF
--- a/.claude/skills/mcp-db-tools/SKILL.md
+++ b/.claude/skills/mcp-db-tools/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: mcp-db-tools
 description: Direct database access tools for MCP writing system using executable scripts
-tags: [database, postgres, mcp, writing, authors, books]
-version: 1.0.0
 ---
 
 # MCP Database Tools Skill


### PR DESCRIPTION
- Rename skill.md to SKILL.md (uppercase per Claude skills requirements)
- Remove non-standard front matter fields (tags, version)
- Keep only required fields (name, description) in YAML front matter

Refs: https://github.com/anthropics/skills