### PR TITLE
Fix SQL syntax error in init.sql

### DIFF
--- a/distribution/docker/init.sql
+++ b/distribution/docker/init.sql
@@ -80,12 +80,12 @@ CREATE TABLE IF NOT EXISTS series_timeline (
 
 -- Utility function for automatic timestamp updates
 CREATE OR REPLACE FUNCTION update_timestamp()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER AS $function$
 BEGIN
     NEW.updated_at = CURRENT_TIMESTAMP;
     RETURN NEW;
 END;
-$$ language 'plpgsql';
+$function$ language 'plpgsql';
 
 -- Create triggers for automatic timestamp updates
 CREATE OR REPLACE TRIGGER update_authors_timestamp


### PR DESCRIPTION
Fixed delimiter conflict in update_timestamp() function. The function was using $$ delimiter inside a DO $$ block, causing syntax error at line 82. Changed to use $function$ delimiter to resolve the conflict.

This fixes the PostgreSQL initialization error that was preventing MCP-connector from starting in the Docker stack.