### PR TITLE
Fix mcp-connector health check timing issues

### DIFF
--- a/distribution/TROUBLESHOOTING.md
+++ b/distribution/TROUBLESHOOTING.md
@@ -1,0 +1,173 @@
+# MCP Writing System - Troubleshooting Guide
+
+## Common Issues
+
+### 1. MCP Connector Health Check Failing
+
+**Symptom:**
+```
+dependency failed to start: container mcp-connector is unhealthy
+ERROR: Failed to start Docker services
+```
+
+**Causes:**
+- The MCP connector needs time to start up properly (45-60 seconds)
+- It must wait for PostgreSQL to be healthy first
+- The `/ping` endpoint takes time to become available
+
+**Solutions:**
+
+#### Check Container Status
+```powershell
+# Check if containers are running
+docker ps -a
+
+# Check health status
+docker inspect --format='{{.State.Health.Status}}' mcp-connector
+docker inspect --format='{{.State.Health.Status}}' mcp-writing-db
+```
+
+#### View Container Logs
+```powershell
+cd distribution/docker
+
+# View MCP connector logs
+docker-compose logs mcp-connector
+
+# View PostgreSQL logs
+docker-compose logs postgres
+
+# Follow logs in real-time
+docker-compose logs -f
+```
+
+#### Manual Health Check
+```powershell
+# Test the ping endpoint directly
+curl http://localhost:50880/ping
+
+# Or using PowerShell
+Invoke-WebRequest -Uri "http://localhost:50880/ping" -UseBasicParsing
+```
+
+#### Reset and Rebuild
+If the issue persists, try a clean restart:
+
+```powershell
+cd distribution/docker
+
+# Stop and remove containers
+docker-compose down
+
+# Remove volumes (WARNING: This deletes database data)
+docker-compose down -v
+
+# Rebuild and start
+docker-compose up -d --build
+```
+
+### 2. Container is Running but Health Check Still Fails
+
+**Symptom:**
+- Docker logs show no errors
+- Services appear to be running
+- Health check still reports "unhealthy"
+
+**Solutions:**
+
+#### Verify Health Check Configuration
+The health check settings in `docker-compose.yml` and `Dockerfile.mcp-connector`:
+- `start_period: 45s` - Grace period before health checks start
+- `interval: 10s` - Health check runs every 10 seconds
+- `timeout: 5s` - Max time for health check to complete
+- `retries: 5` - Number of failures before marking unhealthy
+
+#### Check Port Conflicts
+```powershell
+# Windows - Check if port 50880 is in use
+netstat -ano | findstr :50880
+
+# Linux/Mac
+lsof -i :50880
+```
+
+#### Verify Environment Variables
+Check that `.env` file has all required variables:
+```
+POSTGRES_PASSWORD=your_secure_password
+MCP_AUTH_TOKEN=your_secure_token
+MCP_CONNECTOR_PORT=50880
+```
+
+### 3. Services Start but Ping Endpoint Returns 404
+
+**Symptom:**
+- Container is healthy
+- But accessing `http://localhost:50880/ping` returns 404
+
+**Solution:**
+The Typing Mind MCP connector (`@typingmind/mcp`) must provide a `/ping` endpoint. Verify:
+
+```powershell
+# Check the connector version
+docker exec mcp-connector npm list @typingmind/mcp
+
+# Try accessing other endpoints
+curl http://localhost:50880/
+```
+
+If the endpoint doesn't exist, the connector package may need updating or the health check may need to use a different endpoint.
+
+### 4. PostgreSQL Fails to Start
+
+**Symptom:**
+```
+PostgreSQL did not become healthy in time
+```
+
+**Solutions:**
+
+#### Check Database Logs
+```powershell
+docker logs mcp-writing-db
+```
+
+#### Verify Password is Set
+Check `.env` file has `POSTGRES_PASSWORD` set
+
+#### Remove Corrupted Volume
+```powershell
+cd distribution/docker
+docker-compose down -v
+docker-compose up -d
+```
+
+## Getting Help
+
+If you're still experiencing issues:
+
+1. Run with verbose output:
+   ```powershell
+   .\setup-all.ps1 -Verbose
+   ```
+
+2. Collect diagnostic information:
+   ```powershell
+   docker ps -a
+   docker logs mcp-connector
+   docker logs mcp-writing-db
+   docker inspect mcp-connector
+   ```
+
+3. Check the GitHub repository for known issues
+
+## Recent Changes
+
+### Health Check Configuration Update
+The health check timing was updated to allow more time for the MCP connector to start:
+- Increased `start_period` from 30s to 45s
+- Increased `interval` from 30s to 10s (more frequent checks)
+- Increased `retries` from 3 to 5
+- Setup script now waits up to 120 seconds (60 attempts × 2s)
+
+This resolves issues where the connector was marked unhealthy during initial startup even though it was functioning correctly.

--- a/distribution/docker/Dockerfile.mcp-connector
+++ b/distribution/docker/Dockerfile.mcp-connector
@@ -40,7 +40,7 @@ USER mcp
 EXPOSE 50880
 
 # Health check endpoint (uses /ping endpoint)
-HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+HEALTHCHECK --interval=10s --timeout=5s --start-period=45s --retries=5 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:50880/ping || exit 1
 
 # Use entrypoint script to handle startup

--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -66,11 +66,11 @@ services:
     networks:
       - mcp-network
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:${MCP_CONNECTOR_PORT:-50880}/ping"]
-      interval: 30s
-      timeout: 3s
-      retries: 3
-      start_period: 30s
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:50880/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 45s
 
   # ========================================
   # Typing Mind Static Web Server

--- a/distribution/setup-all.ps1
+++ b/distribution/setup-all.ps1
@@ -223,8 +223,10 @@ if ($postgresHealth -ne "healthy") {
 
 # Wait for MCP Connector
 Write-Host "  Waiting for MCP Connector..." -ForegroundColor Gray
+Write-Host "  (Initial startup may take 45-60 seconds)" -ForegroundColor DarkGray
 $attempt = 0
-while ($attempt -lt $maxAttempts) {
+$maxConnectorAttempts = 60  # Increased from 30 to allow more time
+while ($attempt -lt $maxConnectorAttempts) {
     $attempt++
     $connectorHealth = docker inspect --format='{{.State.Health.Status}}' mcp-connector 2>$null
 
@@ -233,8 +235,8 @@ while ($attempt -lt $maxAttempts) {
         break
     }
 
-    if ($Verbose) {
-        Write-Host "  Attempt $attempt/$maxAttempts - MCP Connector: $connectorHealth" -ForegroundColor DarkGray
+    if ($Verbose -or ($attempt % 10 -eq 0)) {
+        Write-Host "  Attempt $attempt/$maxConnectorAttempts - MCP Connector: $connectorHealth" -ForegroundColor DarkGray
     }
 
     Start-Sleep -Seconds 2
@@ -242,6 +244,7 @@ while ($attempt -lt $maxAttempts) {
 
 if ($connectorHealth -ne "healthy") {
     Write-Host "  ERROR: MCP Connector did not become healthy" -ForegroundColor Red
+    Write-Host "  Check logs with: cd docker && docker-compose logs mcp-connector" -ForegroundColor Yellow
     exit 1
 }
 

--- a/distribution/setup-all.sh
+++ b/distribution/setup-all.sh
@@ -279,8 +279,10 @@ fi
 
 # Wait for MCP Connector
 echo "  Checking MCP Connector..."
+echo "  (Initial startup may take 45-60 seconds)"
+MAX_CONNECTOR_ATTEMPTS=60  # Increased from 30 to allow more time
 ATTEMPT=0
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+while [ $ATTEMPT -lt $MAX_CONNECTOR_ATTEMPTS ]; do
     ATTEMPT=$((ATTEMPT + 1))
 
     CONNECTOR_HEALTH=$(docker inspect --format='{{.State.Health.Status}}' mcp-connector 2>/dev/null || echo "unknown")
@@ -290,8 +292,9 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
         break
     fi
 
-    if [ "$VERBOSE" = true ]; then
-        echo "  Attempt $ATTEMPT/$MAX_ATTEMPTS - MCP Connector: $CONNECTOR_HEALTH"
+    # Show progress every 10 attempts or if verbose
+    if [ "$VERBOSE" = true ] || [ $((ATTEMPT % 10)) -eq 0 ]; then
+        echo "  Attempt $ATTEMPT/$MAX_CONNECTOR_ATTEMPTS - MCP Connector: $CONNECTOR_HEALTH"
     fi
 
     sleep 2
@@ -299,6 +302,7 @@ done
 
 if [ "$CONNECTOR_HEALTH" != "healthy" ]; then
     echo "✗ MCP Connector did not become healthy in time"
+    echo "  Check logs with: cd docker && docker-compose logs mcp-connector"
     exit 1
 fi
 


### PR DESCRIPTION
The mcp-connector was being marked as unhealthy during initial startup even when functioning correctly. This was causing setup-all.ps1 to fail with "container mcp-connector is unhealthy" errors.

Changes:
- Increased health check start_period from 30s to 45s to allow more time for startup
- Increased health check interval from 30s to 10s for more frequent checks
- Increased health check retries from 3 to 5 for better reliability
- Increased timeout from 3s to 5s to handle slower responses
- Fixed port variable in health check (use hardcoded 50880 instead of ${MCP_CONNECTOR_PORT})
- Updated setup scripts to wait up to 120 seconds (60 attempts) for connector health
- Added progress messages to inform users that startup may take 45-60 seconds
- Added troubleshooting guide (TROUBLESHOOTING.md) with common issues and solutions

The mcp-connector needs time to:
1. Wait for PostgreSQL to become healthy
2. Discover MCP servers
3. Start the connector process
4. Make the /ping endpoint available

These timing adjustments ensure the health check doesn't fail prematurely during the normal startup sequence.